### PR TITLE
[DOCS] 프로젝트 하네스 문서 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Beatly Agent Instructions
+
+이 파일은 Beatly에서 작업하는 AI 에이전트가 매 작업 전에 따라야 하는 핵심 규약이다.
+악보, 가사, 오디오 분석, 렌더링, API 응답 구조를 변경하기 전에는 반드시 `harness/PROJECT_HARNESS.md`도 확인한다.
+
+## Ultimate Goal
+
+MP3 업로드만으로 실제 드러머가 바로 읽고 연주할 수 있는 전문 드럼 악보를 생성한다.
+드럼 비트와 한국어 가사는 같은 시간축 위에서 동기화되어야 하며, 가사는 악보 하단의 독립 Lyric Lane에 겹침 없이 표시되어야 한다.
+
+## Mandatory Rules
+
+- PAS 기준 드럼 위치를 고정한다.
+- Kick: `f/4`, MIDI 36, Voice 2, normal notehead.
+- Snare: `c/5`, MIDI 38, Voice 1, normal notehead.
+- Hi-hat closed/open: `g/5`, MIDI 42/46, Voice 1, `x` notehead.
+- 손 성부는 Voice 1, stem up으로 유지한다.
+- 발 성부는 Voice 2, stem down으로 유지한다.
+- 발 성부에는 긴 연결 beam이나 조밀한 16분 beam이 생기지 않게 한다.
+- 모든 드럼 이벤트는 최소 16분 음표 슬롯으로 퀀타이즈한다.
+- 32분/64분 음표나 그에 준하는 세밀한 리듬 표기는 만들지 않는다.
+- 드럼 히트가 없는 슬롯이라도 해당 시간에 가사가 있으면 Lyric Lane에 반드시 남긴다.
+- 가사는 드럼 이벤트의 `lyric` 필드에 의존하지 말고 독립 가사 슬롯으로 보존한다.
+- Whisper는 `word_timestamps=True`를 사용해야 한다.
+- Whisper 모델은 캐시/프리로드로 재사용하고 요청마다 재로드하지 않는다.
+
+## Hard Constraints
+
+- 3개 이상의 동시 손 타격을 기보하지 않는다.
+- 노이즈성 초고속 킥 연타를 그대로 기보하지 않는다.
+- Voice 1에는 손 악기만, Voice 2에는 kick만 들어가야 한다.
+- 한국어 가사 음절을 한 슬롯에 과도하게 뭉치게 하지 않는다.
+- 후처리 중 `lyric=None`으로 기존 가사 데이터를 증발시키지 않는다.
+- 음표 밖으로 삐져나온 beam, 휘어진 flag, 수직 정렬 오류를 방치하지 않는다.
+- 기존 사용자 변경을 되돌리지 않는다.
+
+## Pipeline Contract
+
+1. Demucs로 vocals/drums stem을 분리한다.
+2. drums stem에서 드럼 히트를 분석한다.
+3. vocals stem에서 Whisper 단어 타임스탬프를 추출한다.
+4. 드럼 히트와 가사를 1/16 슬롯 좌표로 병합한다.
+5. 백엔드 표기 후처리에서 PAS 매핑, 성부 분리, 연주 가능성, 킥 밀도 제한을 적용한다.
+6. 프론트엔드 `DrumSheet.tsx`는 드럼 음표와 별개로 Lyric Lane을 렌더링한다.
+
+## Required Checks
+
+악보, 가사 정렬, 드럼 분석, Whisper, 또는 `DrumSheet.tsx`를 변경했다면 가능한 경우 다음 하네스를 실행한다.
+
+```powershell
+py -3 harness\beatly_quality_harness.py
+```
+
+Python이 `python` 명령으로 설치된 환경에서는 다음을 사용한다.
+
+```powershell
+python harness\beatly_quality_harness.py
+```
+
+실행할 수 없는 환경이면 최종 보고에 그 이유를 명시한다.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ Then open:
 }
 ```
 
+## Project Harness
+
+The project contract lives in `harness/PROJECT_HARNESS.md`. It captures the
+ultimate goal, notation rules, hard constraints, and technical pipeline for
+producing drummer-ready sheets with synchronized lyrics.
+
+Run the executable quality harness from the repository root:
+
+```powershell
+py -3 harness\beatly_quality_harness.py
+# or, if Python is installed as `python`:
+python harness\beatly_quality_harness.py
+```
+
+The harness checks PAS drum mapping, voice separation, 16th-note quantization,
+lyric-slot preservation, playable hand/bass constraints, and Whisper model
+caching expectations.
+
 ## Notes
 
 The backend contains the production hooks for Demucs and Whisper, but those

--- a/harness/PROJECT_HARNESS.md
+++ b/harness/PROJECT_HARNESS.md
@@ -1,0 +1,76 @@
+# Beatly Project Harness
+
+이 하네스는 Beatly의 품질 기준을 코드 변경 시마다 비교할 수 있는 프로젝트 계약이다.
+최종 산출물은 "MP3 업로드 -> 드러머가 바로 읽고 연주할 수 있는 드럼 악보 + 시간 동기화 가사"여야 한다.
+
+## Ultimate Goal
+
+- 사용자는 MP3 파일을 업로드한다.
+- 시스템은 실제 드러머가 즉시 연주할 수 있는 깨끗하고 전문적인 악보를 생성한다.
+- 악보는 기성 드럼 악보 수준의 가독성, 마디 배치, 성부 분리, 리듬 정렬을 갖춘다.
+- 드럼 비트와 한국어 가사는 하나의 시간축에서 결합되며, 가사는 악보 하단의 독립 Lyric Lane에 겹침 없이 배치된다.
+
+## Mandatory Rules
+
+- 표준 드럼 기보법을 따른다.
+- PAS 기준 매핑을 고정한다.
+- 베이스 드럼: 1번 칸, `f/4`, Voice 2, 아래 기둥.
+- 스네어: 3번 칸, `c/5`, Voice 1, 위 기둥.
+- 하이햇: 5번 선, `g/5`, `x` notehead, Voice 1, 위 기둥.
+- 손 성부와 발 성부를 분리한다.
+- 손: Voice 1, stem up.
+- 발: Voice 2, stem down.
+- 발 성부에는 긴 연결 보를 만들지 않는다.
+- 모든 리듬은 최소 16분 음표 슬롯으로 퀀타이즈한다.
+- 32분/64분 음표는 생성하지 않는다.
+- 드럼 히트가 없는 시간이라도 가사가 있으면 해당 16분 슬롯에 가사를 반드시 유지한다.
+- Whisper는 `large-v3` 계열 모델과 `word_timestamps=True` 방식으로 단어 시작/종료 시간을 확보하는 구성을 목표로 한다.
+- Whisper 모델은 앱 시작 시 또는 캐시된 로더를 통해 재사용하고, 요청마다 새로 로드하지 않는다.
+
+## Hard Constraints
+
+- 사람이 연주할 수 없는 3개 이상의 동시 손 타격을 기보하지 않는다.
+- 초고속 베이스 드럼 연타나 노이즈성 킥을 그대로 기보하지 않는다.
+- 음표 밖으로 삐져나온 beam, 휘어진 flag, 수직 정렬이 맞지 않는 음표 더미를 방치하지 않는다.
+- 한국어 가사 음절을 한 슬롯에 과도하게 뭉치게 하지 않는다.
+- 후처리 과정에서 `lyric=None`으로 가사 데이터를 증발시키지 않는다.
+- Demucs/Whisper 같은 무거운 모델을 매 요청마다 재로드하지 않는다.
+
+## Technical Pipeline Contract
+
+1. 전처리: Demucs로 `vocals.wav`와 `drums.wav`를 분리한다.
+2. 드럼 분석: 분리된 드럼 트랙에서 히트 시점과 악기군을 추출한다.
+3. 가사 추출: 분리된 보컬 트랙에서 Whisper `word_timestamps=True`로 단어 단위 타임스탬프를 얻는다.
+4. 병합: 단어 타임스탬프와 드럼 히트를 같은 1/16 슬롯 좌표로 변환한다.
+5. 기보 후처리: PAS 매핑, 성부 분리, 연주 가능성, 16분 퀀타이즈, 킥 밀도 제한을 적용한다.
+6. 렌더링: `DrumSheet.tsx`는 드럼 음표와 별개로 Lyric Lane을 그린다.
+
+## Acceptance Gates
+
+- API 응답의 `midi_ticks`는 모두 `tick % 120 == 0`이어야 한다.
+- `engraved_measures[*].voice1`과 `voice2`는 각 마디마다 4/4 박자 합계를 만족해야 한다.
+- `duration`은 `q`, `8`, `16`만 허용한다.
+- Voice 1에는 손 악기만, Voice 2에는 킥만 들어간다.
+- 같은 tick의 손 악기는 최대 2개까지만 허용한다.
+- Voice 2는 16분 연속 보를 만들 수 있는 출력으로 남기지 않는다.
+- `words`에 존재하는 가사는 `engraved_measures[*].lyric_slots` 또는 `slots`에 남아 있어야 한다.
+- 하이햇은 `g/5` + `x`, 스네어는 `c/5` + normal, 킥은 `f/4` + normal로 렌더링되어야 한다.
+
+## Executable Harness
+
+실행 가능한 검증 스크립트는 `harness/beatly_quality_harness.py`에 있다.
+
+```powershell
+py -3 harness\beatly_quality_harness.py
+# 또는 Python이 `python` 명령으로 설치된 환경:
+python harness\beatly_quality_harness.py
+```
+
+이 스크립트는 현재 백엔드 표기 로직을 대상으로 다음 회귀 케이스를 검사한다.
+
+- PAS 매핑과 성부 분리
+- 16분 슬롯 퀀타이즈와 32분/64분 금지
+- 드럼 히트가 없는 슬롯의 가사 보존
+- 3개 이상 동시 손 타격 제거
+- 과도한 킥 밀도 제한과 발 성부 16분 beam 방지
+- Whisper 모델 캐시/프리로드 구조 유지


### PR DESCRIPTION
﻿## 변경 내용 요약
- Beatly 작업 기준을 담은 AGENTS.md를 추가했습니다.
- 프로젝트 하네스 계약 문서와 README 안내를 추가했습니다.

## 변경 이유
- 악보, 가사, 오디오 분석 변경 전 확인할 품질 기준을 명확히 하기 위해서입니다.

## 주요 변경 사항
- PAS 매핑, 성부 분리, 16분 퀀타이즈, Lyric Lane 보존 규칙을 문서화했습니다.
- 하네스 실행 위치와 사용 명령을 README에 연결했습니다.

## 테스트 방법
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`
