### PR TITLE
[FULL] 유튜브 링크 분석과 캡션 가사 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ with synchronized lyrics.
 
 ## Apps
 
-- `apps/api`: FastAPI backend. Separates drums with Demucs, analyzes drum hits
-  with librosa, transcribes lyrics with Whisper, and returns a merged JSON score.
-- `apps/web`: Next.js frontend. Uploads MP3 files and renders drum notation with
-  VexFlow plus beat-aligned lyrics.
+- `apps/api`: FastAPI backend. Accepts MP3 uploads or YouTube links, separates
+  drums with Demucs, analyzes drum hits with librosa, prefers YouTube captions
+  when available, falls back to Whisper, and returns a merged JSON score.
+- `apps/web`: Next.js frontend. Submits MP3 files or YouTube links and renders
+  drum notation with VexFlow plus beat-aligned lyrics.
 
 ## Quick Start
 
@@ -24,6 +25,11 @@ Then open:
 ## API Shape
 
 `POST /analyze` accepts `multipart/form-data` with a `file` field and returns:
+
+`POST /analyze/youtube/jobs` accepts `multipart/form-data` with `youtube_url`.
+The job result has the same `AnalysisResult` shape as MP3 analysis. Korean
+YouTube captions are used first when present; if captions are missing, the
+downloaded audio follows the existing Demucs -> vocals -> Whisper path.
 
 ```json
 {

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     upload_dir: Path = Field(default=Path("uploads"), alias="BEATLY_UPLOAD_DIR")
     separated_dir: Path = Field(default=Path("separated"), alias="BEATLY_SEPARATED_DIR")
     analysis_cache_dir: Path = Field(default=Path("analysis-cache"), alias="BEATLY_ANALYSIS_CACHE_DIR")
+    youtube_dir: Path = Field(default=Path("youtube"), alias="BEATLY_YOUTUBE_DIR")
     whisper_model: str = Field(default="large-v3-turbo", alias="WHISPER_MODEL")
     whisper_engine: str = Field(default="faster-whisper", alias="WHISPER_ENGINE")
     whisper_device: str = Field(default="cpu", alias="WHISPER_DEVICE")
@@ -34,6 +35,7 @@ def get_settings() -> Settings:
     settings.upload_dir.mkdir(parents=True, exist_ok=True)
     settings.separated_dir.mkdir(parents=True, exist_ok=True)
     settings.analysis_cache_dir.mkdir(parents=True, exist_ok=True)
+    settings.youtube_dir.mkdir(parents=True, exist_ok=True)
     if settings.whisper_download_root is not None:
         settings.whisper_download_root.mkdir(parents=True, exist_ok=True)
     return settings

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -22,6 +22,7 @@ from app.services.drum_separation import DrumSeparationError, separate_stems_wit
 from app.services.lyrics import preload_whisper_model, transcribe_words_with_whisper
 from app.services.notation import TICKS_PER_QUARTER, build_engraved_measures, build_midi_tick_list
 from app.services.score_merge import build_lyric_lane, merge_drums_and_lyrics
+from app.services.youtube_source import YouTubeSourceError, is_youtube_url, prepare_youtube_source
 
 logger = logging.getLogger("uvicorn.error")
 KOREAN_WHISPER_MODEL_FALLBACK = "large-v3-turbo"
@@ -106,6 +107,33 @@ async def start_analysis_job(
     return job
 
 
+@app.post("/analyze/youtube/jobs", response_model=AnalysisJobStatus)
+async def start_youtube_analysis_job(
+    background_tasks: BackgroundTasks,
+    youtube_url: str = Form(...),
+    enable_lyrics: bool | None = Form(default=None),
+) -> AnalysisJobStatus:
+    settings = get_settings()
+    if not is_youtube_url(youtube_url):
+        raise HTTPException(status_code=400, detail="Enter a valid YouTube URL.")
+
+    should_extract_lyrics = settings.enable_lyrics if enable_lyrics is None else enable_lyrics
+    request_id = uuid4().hex[:8]
+    job = AnalysisJobStatus(
+        job_id=request_id,
+        status="queued",
+        detail="Queued for YouTube analysis.",
+    )
+    _set_job(job)
+    background_tasks.add_task(
+        _run_youtube_analysis_job,
+        request_id,
+        youtube_url,
+        should_extract_lyrics,
+    )
+    return job
+
+
 @app.get("/analyze/jobs/{job_id}", response_model=AnalysisJobStatus)
 def get_analysis_job(job_id: str) -> AnalysisJobStatus:
     job = _get_job(job_id)
@@ -137,36 +165,94 @@ def _run_analysis_job(
     _update_job(job_id, status="succeeded", detail="Analysis finished.", result=result)
 
 
+def _run_youtube_analysis_job(
+    job_id: str,
+    youtube_url: str,
+    should_extract_lyrics: bool,
+) -> None:
+    settings = get_settings()
+    _update_job(job_id, status="running", detail="Fetching YouTube audio and captions.")
+    try:
+        youtube_source = prepare_youtube_source(
+            youtube_url,
+            settings.youtube_dir / job_id,
+            fetch_captions=should_extract_lyrics,
+            progress=lambda detail: _update_job(job_id, status="running", detail=detail),
+        )
+        caption_words = youtube_source.caption_words if should_extract_lyrics else None
+        if caption_words:
+            logger.info(
+                "[%s] youtube captions selected source=%s words=%d",
+                job_id,
+                youtube_source.caption_source,
+                len(caption_words),
+            )
+            _update_job(job_id, status="running", detail="Using YouTube captions for lyrics.")
+        else:
+            logger.info("[%s] youtube captions unavailable; using existing lyric extraction path", job_id)
+            if should_extract_lyrics:
+                _update_job(job_id, status="running", detail="No YouTube captions found. Using Whisper.")
+
+        result = _run_analysis(
+            youtube_source.audio_path,
+            youtube_source.title,
+            job_id,
+            should_extract_lyrics and not caption_words,
+            progress=lambda detail: _update_job(job_id, status="running", detail=detail),
+            provided_words=caption_words,
+            lyric_source_key=youtube_source.lyric_cache_key,
+        )
+    except YouTubeSourceError as exc:
+        logger.exception("[%s] youtube analysis setup failed", job_id)
+        _update_job(job_id, status="failed", detail=str(exc), result=None)
+        return
+    except Exception as exc:
+        logger.exception("[%s] youtube analysis failed", job_id)
+        _update_job(job_id, status="failed", detail=f"Analysis failed: {exc}", result=None)
+        return
+
+    _update_job(job_id, status="succeeded", detail="Analysis finished.", result=result)
+
+
 def _run_analysis(
     upload_path: Path,
     original_filename: str,
     request_id: str,
     should_extract_lyrics: bool,
     progress: Callable[[str], None] | None = None,
+    provided_words: list[LyricWord] | None = None,
+    lyric_source_key: str | None = None,
 ) -> AnalysisResult:
     settings = get_settings()
     analysis_started = time.perf_counter()
     logger.info("[%s] analysis started for %s", request_id, original_filename)
     upload_hash = _file_sha256(upload_path)
+    has_provided_lyrics = bool(provided_words)
+    needs_whisper_lyrics = should_extract_lyrics and not has_provided_lyrics
+    has_any_lyrics = should_extract_lyrics or has_provided_lyrics
     demucs_mode = _demucs_mode_for_request(
         settings.demucs_mode,
-        should_extract_lyrics,
+        needs_whisper_lyrics,
         settings.force_vocals_for_lyrics,
     )
-    whisper_model = _korean_whisper_model(settings.whisper_model) if should_extract_lyrics else settings.whisper_model
+    whisper_model = _korean_whisper_model(settings.whisper_model) if needs_whisper_lyrics else settings.whisper_model
     cache_key = _analysis_cache_key(
         upload_hash,
-        should_extract_lyrics,
+        has_any_lyrics,
         demucs_mode,
         whisper_model,
         settings,
+        lyric_source_key=lyric_source_key,
     )
     if cached_result := _load_cached_analysis(settings.analysis_cache_dir, cache_key):
         logger.info("[%s] analysis cache hit key=%s", request_id, cache_key[:12])
         _report_progress(progress, "Loaded cached analysis.")
         return cached_result
 
-    if should_extract_lyrics and settings.whisper_engine.strip().lower() in {"faster-whisper", "faster_whisper", "ctranslate2", "ct2"}:
+    if (
+        needs_whisper_lyrics
+        and settings.whisper_engine.strip().lower() in {"faster-whisper", "faster_whisper", "ctranslate2", "ct2"}
+    ):
         _report_progress(progress, "Preparing Korean lyric model cache.")
         preload_whisper_model(
             whisper_model,
@@ -198,7 +284,7 @@ def _run_analysis(
         stems.drums,
         stems.vocals,
         settings.separated_dir / upload_path.stem / "prepared",
-        include_vocals=should_extract_lyrics,
+        include_vocals=needs_whisper_lyrics,
     )
     logger.info("[%s] audio preprocessing finished in %.1fs", request_id, time.perf_counter() - step_started)
 
@@ -213,7 +299,10 @@ def _run_analysis(
         len(drum_events),
     )
 
-    if should_extract_lyrics:
+    if has_provided_lyrics:
+        words = sorted(provided_words, key=lambda item: (item.start, item.end))
+        logger.info("[%s] lyric transcription skipped because %d caption words were provided", request_id, len(words))
+    elif needs_whisper_lyrics:
         step_started = time.perf_counter()
         _report_progress(progress, "Transcribing Korean lyrics with Whisper.")
         logger.info(
@@ -357,6 +446,7 @@ def _analysis_cache_key(
     demucs_mode: str,
     whisper_model: str,
     settings: object,
+    lyric_source_key: str | None = None,
 ) -> str:
     payload = {
         "audio_sha256": upload_hash,
@@ -372,6 +462,7 @@ def _analysis_cache_key(
         "whisper_engine": getattr(settings, "whisper_engine", None),
         "whisper_model": whisper_model,
         "whisper_vad_filter": getattr(settings, "whisper_vad_filter", None),
+        "lyric_source_key": lyric_source_key,
     }
     serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()

--- a/apps/api/app/services/youtube_source.py
+++ b/apps/api/app/services/youtube_source.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+from urllib.request import Request, urlopen
+
+from app.models import LyricWord
+
+logger = logging.getLogger("uvicorn.error")
+
+CAPTION_MIN_DURATION_SECONDS = 0.1
+MAX_UNSPLIT_KOREAN_SYLLABLES = 2
+USER_AGENT = "Beatly/0.1 (+https://localhost)"
+YOUTUBE_HOST_PATTERN = re.compile(r"(youtube\.com|youtu\.be|music\.youtube\.com)", re.IGNORECASE)
+VTT_TIME_PATTERN = re.compile(
+    r"(?P<start>(?:\d+:)?\d{2}:\d{2}\.\d{3})\s+-->\s+"
+    r"(?P<end>(?:\d+:)?\d{2}:\d{2}\.\d{3})"
+)
+
+
+class YouTubeSourceError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class YouTubeSource:
+    audio_path: Path
+    title: str
+    webpage_url: str
+    caption_words: list[LyricWord] | None
+    caption_source: str | None
+    lyric_cache_key: str | None
+
+
+@dataclass(frozen=True)
+class CaptionCue:
+    start: float
+    end: float
+    text: str
+
+
+def is_youtube_url(url: str) -> bool:
+    return bool(YOUTUBE_HOST_PATTERN.search(url.strip()))
+
+
+def prepare_youtube_source(
+    youtube_url: str,
+    output_dir: Path,
+    fetch_captions: bool = True,
+    progress: Callable[[str], None] | None = None,
+) -> YouTubeSource:
+    url = youtube_url.strip()
+    if not is_youtube_url(url):
+        raise YouTubeSourceError("Enter a valid YouTube URL.")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _report(progress, "Fetching YouTube metadata.")
+    info = _extract_info(url)
+    title = str(info.get("title") or info.get("id") or "YouTube audio")
+    webpage_url = str(info.get("webpage_url") or url)
+
+    caption_words: list[LyricWord] | None = None
+    caption_source: str | None = None
+    lyric_cache_key: str | None = None
+    if fetch_captions:
+        _report(progress, "Checking YouTube captions.")
+        caption = _fetch_best_caption(info)
+        if caption is not None:
+            caption_source, caption_payload, caption_ext = caption
+            cues = _parse_caption_payload(caption_payload, caption_ext)
+            caption_words = _caption_cues_to_words(cues)
+            if caption_words:
+                lyric_cache_key = _caption_cache_key(caption_source, caption_payload)
+                logger.info(
+                    "youtube captions selected source=%s cues=%d words=%d",
+                    caption_source,
+                    len(cues),
+                    len(caption_words),
+                )
+            else:
+                caption_words = None
+                caption_source = None
+
+    _report(progress, "Downloading YouTube audio.")
+    audio_path = _download_audio(url, output_dir)
+    return YouTubeSource(
+        audio_path=audio_path,
+        title=title,
+        webpage_url=webpage_url,
+        caption_words=caption_words,
+        caption_source=caption_source,
+        lyric_cache_key=lyric_cache_key,
+    )
+
+
+def _extract_info(url: str) -> dict[str, Any]:
+    from yt_dlp import YoutubeDL
+    from yt_dlp.utils import DownloadError
+
+    options: dict[str, Any] = {
+        "quiet": True,
+        "no_warnings": True,
+        "noplaylist": True,
+        "skip_download": True,
+        "retries": 3,
+        "fragment_retries": 3,
+    }
+    try:
+        with YoutubeDL(options) as ydl:
+            info = ydl.extract_info(url, download=False)
+    except DownloadError as exc:
+        raise YouTubeSourceError(f"Could not read YouTube metadata: {exc}") from exc
+
+    if not isinstance(info, dict):
+        raise YouTubeSourceError("Could not read YouTube metadata.")
+    return info
+
+
+def _download_audio(url: str, output_dir: Path) -> Path:
+    from yt_dlp import YoutubeDL
+    from yt_dlp.utils import DownloadError
+
+    output_template = str(output_dir / "source.%(ext)s")
+    options: dict[str, Any] = {
+        "format": "bestaudio/best",
+        "outtmpl": output_template,
+        "quiet": True,
+        "no_warnings": True,
+        "noplaylist": True,
+        "retries": 3,
+        "fragment_retries": 3,
+        "postprocessors": [
+            {
+                "key": "FFmpegExtractAudio",
+                "preferredcodec": "mp3",
+                "preferredquality": "192",
+            }
+        ],
+    }
+    try:
+        with YoutubeDL(options) as ydl:
+            ydl.download([url])
+    except DownloadError as exc:
+        raise YouTubeSourceError(f"Could not download YouTube audio: {exc}") from exc
+
+    audio_files = [
+        path
+        for path in output_dir.glob("source.*")
+        if path.is_file() and path.suffix.lower() not in {".part", ".ytdl", ".json"}
+    ]
+    if not audio_files:
+        raise YouTubeSourceError("YouTube audio download finished but no audio file was found.")
+    return sorted(audio_files, key=lambda path: path.stat().st_mtime, reverse=True)[0]
+
+
+def _fetch_best_caption(info: dict[str, Any]) -> tuple[str, str, str] | None:
+    candidates = [
+        ("official", info.get("subtitles") or {}),
+        ("auto", info.get("automatic_captions") or {}),
+    ]
+    for source_kind, tracks in candidates:
+        selected = _select_caption_track(tracks)
+        if selected is None:
+            continue
+        language, caption_format = selected
+        caption_url = str(caption_format.get("url") or "")
+        caption_ext = str(caption_format.get("ext") or "").lower()
+        if not caption_url:
+            continue
+        try:
+            payload = _download_text(caption_url)
+        except Exception:
+            logger.exception("Could not fetch YouTube caption language=%s source=%s", language, source_kind)
+            continue
+        return f"{source_kind}:{language}", payload, caption_ext
+    return None
+
+
+def _select_caption_track(tracks: dict[str, list[dict[str, Any]]]) -> tuple[str, dict[str, Any]] | None:
+    if not tracks:
+        return None
+
+    languages = list(tracks.keys())
+    preferred_languages = [
+        language for language in languages if language.lower() in {"ko", "ko-kr"} or language.lower().startswith("ko-")
+    ]
+    preferred_languages.extend(language for language in languages if language not in preferred_languages)
+
+    for language in preferred_languages:
+        formats = tracks.get(language) or []
+        selected_format = _select_caption_format(formats)
+        if selected_format is not None:
+            return language, selected_format
+    return None
+
+
+def _select_caption_format(formats: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for preferred_ext in ("vtt", "json3", "srv3", "ttml"):
+        for caption_format in formats:
+            if str(caption_format.get("ext") or "").lower() == preferred_ext:
+                return caption_format
+    return formats[0] if formats else None
+
+
+def _download_text(url: str) -> str:
+    request = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(request, timeout=20) as response:
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.read().decode(charset, errors="replace")
+
+
+def _parse_caption_payload(payload: str, caption_ext: str) -> list[CaptionCue]:
+    if caption_ext == "json3" or payload.lstrip().startswith("{"):
+        return _parse_json3_captions(payload)
+    return _parse_vtt_captions(payload)
+
+
+def _parse_json3_captions(payload: str) -> list[CaptionCue]:
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return []
+
+    cues: list[CaptionCue] = []
+    for event in data.get("events", []):
+        segments = event.get("segs") or []
+        text = "".join(str(segment.get("utf8", "")) for segment in segments)
+        if not text.strip():
+            continue
+        start = float(event.get("tStartMs", 0)) / 1000
+        duration = float(event.get("dDurationMs", 0)) / 1000
+        end = start + max(duration, CAPTION_MIN_DURATION_SECONDS)
+        cues.append(CaptionCue(start=start, end=end, text=text))
+    return cues
+
+
+def _parse_vtt_captions(payload: str) -> list[CaptionCue]:
+    cues: list[CaptionCue] = []
+    lines = payload.replace("\ufeff", "").splitlines()
+    index = 0
+    while index < len(lines):
+        match = VTT_TIME_PATTERN.search(lines[index])
+        if not match:
+            index += 1
+            continue
+        start = _parse_vtt_time(match.group("start"))
+        end = _parse_vtt_time(match.group("end"))
+        index += 1
+        text_lines: list[str] = []
+        while index < len(lines) and lines[index].strip():
+            text_lines.append(lines[index])
+            index += 1
+        text = " ".join(text_lines)
+        if text.strip():
+            cues.append(CaptionCue(start=start, end=max(end, start + CAPTION_MIN_DURATION_SECONDS), text=text))
+    return cues
+
+
+def _parse_vtt_time(value: str) -> float:
+    parts = value.split(":")
+    if len(parts) == 3:
+        hours = int(parts[0])
+        minutes = int(parts[1])
+        seconds = float(parts[2])
+    else:
+        hours = 0
+        minutes = int(parts[0])
+        seconds = float(parts[1])
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def _caption_cues_to_words(cues: list[CaptionCue]) -> list[LyricWord]:
+    words: list[LyricWord] = []
+    previous_text = ""
+    for cue in cues:
+        text = _clean_caption_text(cue.text)
+        if not text or text == previous_text:
+            continue
+        previous_text = text
+        units = _expand_caption_units(text)
+        if not units:
+            continue
+        duration = max(cue.end - cue.start, CAPTION_MIN_DURATION_SECONDS * len(units))
+        step = duration / len(units)
+        for index, unit in enumerate(units):
+            start = cue.start + index * step
+            end = cue.start + (index + 1) * step
+            words.append(_lyric_word(unit, start, end))
+    return _sanitize_word_timeline(words)
+
+
+def _clean_caption_text(text: str) -> str:
+    cleaned = html.unescape(text)
+    cleaned = re.sub(r"<[^>]+>", " ", cleaned)
+    cleaned = re.sub(r"\[[^\]]+\]|\([^\)]*(?:음악|music|applause|박수)[^\)]*\)", " ", cleaned, flags=re.IGNORECASE)
+    cleaned = cleaned.replace("♪", " ").replace("♫", " ")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return unicodedata.normalize("NFC", cleaned.strip())
+
+
+def _expand_caption_units(text: str) -> list[str]:
+    units: list[str] = []
+    for token in text.split():
+        normalized = _strip_token(token)
+        if not normalized:
+            continue
+        syllables = [char for char in normalized if _is_hangul_syllable(char)]
+        if len(syllables) > MAX_UNSPLIT_KOREAN_SYLLABLES:
+            units.extend(syllables)
+        else:
+            units.append(normalized)
+    return units
+
+
+def _strip_token(token: str) -> str:
+    return unicodedata.normalize("NFC", token.strip(".,!?;:\"'()[]{}<>“”‘’"))
+
+
+def _sanitize_word_timeline(words: list[LyricWord]) -> list[LyricWord]:
+    sanitized: list[LyricWord] = []
+    previous_end = 0.0
+    for word in sorted(words, key=lambda item: (item.start, item.end)):
+        text = unicodedata.normalize("NFC", word.word.strip())
+        if not text:
+            continue
+        start = max(0.0, float(word.start))
+        end = max(start + CAPTION_MIN_DURATION_SECONDS, float(word.end))
+        if sanitized and start < previous_end:
+            start = previous_end
+            end = max(start + CAPTION_MIN_DURATION_SECONDS, end)
+        sanitized.append(_lyric_word(text, start, end))
+        previous_end = sanitized[-1].end
+    return sanitized
+
+
+def _lyric_word(word: str, start: float, end: float) -> LyricWord:
+    safe_start = round(max(0.0, start), 3)
+    safe_end = round(max(safe_start + CAPTION_MIN_DURATION_SECONDS, end), 3)
+    return LyricWord(word=unicodedata.normalize("NFC", word.strip()), start=safe_start, end=safe_end)
+
+
+def _is_hangul_syllable(char: str) -> bool:
+    return 0xAC00 <= ord(char) <= 0xD7A3
+
+
+def _caption_cache_key(caption_source: str, payload: str) -> str:
+    digest = hashlib.sha256()
+    digest.update(caption_source.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(payload.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _report(progress: Callable[[str], None] | None, detail: str) -> None:
+    if progress is not None:
+        progress(detail)

--- a/apps/api/app/services/youtube_source.py
+++ b/apps/api/app/services/youtube_source.py
@@ -16,7 +16,8 @@ from app.models import LyricWord
 logger = logging.getLogger("uvicorn.error")
 
 CAPTION_MIN_DURATION_SECONDS = 0.1
-MAX_UNSPLIT_KOREAN_SYLLABLES = 2
+CAPTION_LAYOUT_VERSION = "youtube-caption-grid-v2"
+CAPTION_ROLLING_OVERLAP_SECONDS = 0.75
 USER_AGENT = "Beatly/0.1 (+https://localhost)"
 YOUTUBE_HOST_PATTERN = re.compile(r"(youtube\.com|youtu\.be|music\.youtube\.com)", re.IGNORECASE)
 VTT_TIME_PATTERN = re.compile(
@@ -279,20 +280,36 @@ def _parse_vtt_time(value: str) -> float:
 def _caption_cues_to_words(cues: list[CaptionCue]) -> list[LyricWord]:
     words: list[LyricWord] = []
     previous_text = ""
+    previous_units: list[str] = []
+    previous_end = 0.0
     for cue in cues:
         text = _clean_caption_text(cue.text)
-        if not text or text == previous_text:
+        if not text:
+            continue
+        raw_units = _expand_caption_units(text)
+        if text == previous_text:
+            previous_units = raw_units
+            previous_end = max(previous_end, cue.end)
             continue
         previous_text = text
-        units = _expand_caption_units(text)
+        units = raw_units
+        start_base = cue.start
+        if cue.start <= previous_end + CAPTION_ROLLING_OVERLAP_SECONDS:
+            units = _trim_rolling_caption_units(units, previous_units)
+            if len(units) < len(raw_units):
+                start_base = max(cue.start, previous_end)
         if not units:
+            previous_units = raw_units
+            previous_end = max(previous_end, cue.end)
             continue
-        duration = max(cue.end - cue.start, CAPTION_MIN_DURATION_SECONDS * len(units))
+        duration = max(cue.end - start_base, CAPTION_MIN_DURATION_SECONDS * len(units))
         step = duration / len(units)
         for index, unit in enumerate(units):
-            start = cue.start + index * step
-            end = cue.start + (index + 1) * step
+            start = start_base + index * step
+            end = start_base + (index + 1) * step
             words.append(_lyric_word(unit, start, end))
+        previous_units = raw_units
+        previous_end = max(previous_end, cue.end)
     return _sanitize_word_timeline(words)
 
 
@@ -307,15 +324,43 @@ def _clean_caption_text(text: str) -> str:
 
 def _expand_caption_units(text: str) -> list[str]:
     units: list[str] = []
-    for token in text.split():
-        normalized = _strip_token(token)
-        if not normalized:
+    buffer: list[str] = []
+
+    def flush_buffer() -> None:
+        if not buffer:
+            return
+        token = _strip_token("".join(buffer))
+        if token:
+            units.append(token)
+        buffer.clear()
+
+    for char in unicodedata.normalize("NFC", text):
+        if _is_hangul_syllable(char):
+            flush_buffer()
+            units.append(char)
             continue
-        syllables = [char for char in normalized if _is_hangul_syllable(char)]
-        if len(syllables) > MAX_UNSPLIT_KOREAN_SYLLABLES:
-            units.extend(syllables)
-        else:
-            units.append(normalized)
+        if char.isspace() or unicodedata.category(char).startswith("P"):
+            flush_buffer()
+            continue
+        buffer.append(char)
+
+    flush_buffer()
+    return units
+
+
+def _trim_rolling_caption_units(units: list[str], previous_units: list[str]) -> list[str]:
+    if not units or not previous_units:
+        return units
+
+    for start in range(0, len(previous_units) - len(units) + 1):
+        if previous_units[start : start + len(units)] == units:
+            return []
+
+    max_overlap = min(len(units), len(previous_units))
+    for size in range(max_overlap, 0, -1):
+        if previous_units[-size:] == units[:size]:
+            return units[size:]
+
     return units
 
 
@@ -352,6 +397,8 @@ def _is_hangul_syllable(char: str) -> bool:
 
 def _caption_cache_key(caption_source: str, payload: str) -> str:
     digest = hashlib.sha256()
+    digest.update(CAPTION_LAYOUT_VERSION.encode("utf-8"))
+    digest.update(b"\0")
     digest.update(caption_source.encode("utf-8"))
     digest.update(b"\0")
     digest.update(payload.encode("utf-8"))

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -9,3 +9,4 @@ soundfile==0.12.1
 openai-whisper==20240930
 faster-whisper==1.1.1
 demucs==4.0.1
+yt-dlp==2026.3.17

--- a/apps/web/app/api/analyze/youtube/jobs/route.ts
+++ b/apps/web/app/api/analyze/youtube/jobs/route.ts
@@ -1,0 +1,50 @@
+const API_INTERNAL_URL = process.env.API_INTERNAL_URL ?? "http://127.0.0.1:8000";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(request: Request): Promise<Response> {
+  const headers = new Headers();
+  const contentType = request.headers.get("content-type");
+  if (contentType) {
+    headers.set("content-type", contentType);
+  }
+
+  const init: RequestInit & { duplex?: "half" } = {
+    method: "POST",
+    headers,
+    body: request.body,
+    cache: "no-store",
+  };
+
+  if (request.body) {
+    init.duplex = "half";
+  }
+
+  try {
+    const upstreamResponse = await fetch(`${trimTrailingSlash(API_INTERNAL_URL)}/analyze/youtube/jobs`, init);
+    return new Response(upstreamResponse.body, {
+      status: upstreamResponse.status,
+      statusText: upstreamResponse.statusText,
+      headers: copyContentType(upstreamResponse.headers),
+    });
+  } catch {
+    return Response.json(
+      { detail: "Could not reach Beatly API. Check that the api container is running." },
+      { status: 502 },
+    );
+  }
+}
+
+function copyContentType(headers: Headers): Headers {
+  const responseHeaders = new Headers();
+  const contentType = headers.get("content-type");
+  if (contentType) {
+    responseHeaders.set("content-type", contentType);
+  }
+  return responseHeaders;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -68,6 +68,33 @@ input {
   border-radius: 8px;
 }
 
+.source-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.source-button {
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--ink);
+  background: #fff;
+  cursor: pointer;
+}
+
+.source-button.active {
+  border-color: var(--accent);
+  color: #fff;
+  background: var(--accent);
+}
+
+.source-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .controls {
   display: flex;
   flex-wrap: wrap;
@@ -84,6 +111,16 @@ input {
 }
 
 .file-input {
+  min-width: 260px;
+  max-width: 100%;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.text-input {
+  flex: 1 1 420px;
   min-width: 260px;
   max-width: 100%;
   padding: 10px;
@@ -166,6 +203,7 @@ input {
   }
 
   .file-input,
+  .text-input,
   .button {
     width: 100%;
   }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,11 +2,15 @@
 
 import { useState } from "react";
 import { DrumSheet } from "@/components/DrumSheet";
-import { analyzeAudio } from "@/lib/api";
-import type { AnalysisResult } from "@/lib/types";
+import { analyzeAudio, analyzeYouTube } from "@/lib/api";
+import type { AnalysisJobStatus, AnalysisResult } from "@/lib/types";
+
+type SourceType = "upload" | "youtube";
 
 export default function Home() {
+  const [sourceType, setSourceType] = useState<SourceType>("upload");
   const [file, setFile] = useState<File | null>(null);
+  const [youtubeUrl, setYoutubeUrl] = useState("");
   const [score, setScore] = useState<AnalysisResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [enableLyrics, setEnableLyrics] = useState(true);
@@ -15,8 +19,12 @@ export default function Home() {
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!file) {
+    if (sourceType === "upload" && !file) {
       setError("Choose an MP3, WAV, M4A, or FLAC file.");
+      return;
+    }
+    if (sourceType === "youtube" && !youtubeUrl.trim()) {
+      setError("Enter a YouTube link.");
       return;
     }
 
@@ -24,12 +32,16 @@ export default function Home() {
     setError(null);
     setStatusText(null);
     try {
-      const result = await analyzeAudio(file, {
+      const options = {
         enableLyrics,
-        onStatus: (job) => {
+        onStatus: (job: AnalysisJobStatus) => {
           setStatusText(formatJobStatus(job.status, job.detail));
         },
-      });
+      };
+      const result =
+        sourceType === "youtube"
+          ? await analyzeYouTube(youtubeUrl.trim(), options)
+          : await analyzeAudio(file as File, options);
       setScore(result);
       setStatusText(null);
     } catch (caught) {
@@ -46,19 +58,48 @@ export default function Home() {
           <div>
             <h1 className="title">Beatly Drum Sheet</h1>
             <p className="subtitle">
-              Upload audio to separate vocals, transcribe Korean lyrics, and generate a synchronized drum score.
+              Upload audio or paste a YouTube link to generate a synchronized drum score.
             </p>
           </div>
         </div>
 
         <form className="upload-panel" onSubmit={onSubmit}>
+          <div className="source-toggle" aria-label="Audio source">
+            <button
+              className={sourceType === "upload" ? "source-button active" : "source-button"}
+              disabled={isLoading}
+              onClick={() => setSourceType("upload")}
+              type="button"
+            >
+              MP3 upload
+            </button>
+            <button
+              className={sourceType === "youtube" ? "source-button active" : "source-button"}
+              disabled={isLoading}
+              onClick={() => setSourceType("youtube")}
+              type="button"
+            >
+              YouTube link
+            </button>
+          </div>
           <div className="controls">
-            <input
-              className="file-input"
-              type="file"
-              accept="audio/mpeg,audio/mp3,audio/wav,audio/flac,audio/mp4"
-              onChange={(event) => setFile(event.target.files?.[0] ?? null)}
-            />
+            {sourceType === "upload" ? (
+              <input
+                className="file-input"
+                type="file"
+                accept="audio/mpeg,audio/mp3,audio/wav,audio/flac,audio/mp4"
+                onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+              />
+            ) : (
+              <input
+                className="text-input"
+                disabled={isLoading}
+                onChange={(event) => setYoutubeUrl(event.target.value)}
+                placeholder="https://www.youtube.com/watch?v=..."
+                type="url"
+                value={youtubeUrl}
+              />
+            )}
             <button className="button" disabled={isLoading} type="submit">
               {isLoading ? "Analyzing..." : "Generate Score"}
             </button>
@@ -69,7 +110,11 @@ export default function Home() {
               onChange={(event) => setEnableLyrics(event.target.checked)}
               type="checkbox"
             />
-            <span>Extract Korean lyrics with Whisper. Slower on CPU.</span>
+            <span>
+              {sourceType === "youtube"
+                ? "Use YouTube captions when available; otherwise use Whisper."
+                : "Extract Korean lyrics with Whisper. Slower on CPU."}
+            </span>
           </label>
           {statusText ? <div className="status">{statusText}</div> : null}
           {error ? <div className="error">{error}</div> : null}

--- a/apps/web/components/DrumSheet.tsx
+++ b/apps/web/components/DrumSheet.tsx
@@ -37,10 +37,12 @@ const MEASURES_PER_LINE = 4;
 const MEASURE_WIDTH = 320;
 const LEFT_MARGIN = 28;
 const TOP_MARGIN = 26;
-const LINE_HEIGHT = 176;
+const LINE_HEIGHT = 196;
 const SLOTS_PER_MEASURE = 16;
-const LYRIC_MIN_GAP_PX = 8;
-const LYRIC_HANGUL_PADDING_PX = 2;
+const LYRIC_FONT_SIZE = 12;
+const LYRIC_MIN_GAP_PX = 6;
+const LYRIC_ROW_GAP_PX = 18;
+const LYRIC_MAX_ROWS = 2;
 
 export function DrumSheet({ score }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -101,7 +103,7 @@ export function DrumSheet({ score }: Props) {
         drawHiHatStateMarks(context, upperNotes[tickIndex], tick);
         drawGhostSnareMarks(context, upperNotes[tickIndex], tick);
       });
-      drawLyricLane(context, stave, measure, upperNotes, upperTicks);
+      drawLyricLane(context, stave, measure);
     });
   }, [measures]);
 
@@ -348,17 +350,10 @@ function drawLyricLane(
   context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
   stave: Stave,
   measure: Measure,
-  notes: StaveNote[],
-  ticks: DisplayTick[],
 ) {
-  const noteXBySlot = new Map<number, number>();
-  ticks.forEach((tick, index) => {
-    noteXBySlot.set(tick.slot, notes[index].getAbsoluteX());
-  });
-
   context.save();
-  context.setFont("Arial, Malgun Gothic, sans-serif", 13);
-  let lastRight = Number.NEGATIVE_INFINITY;
+  context.setFont("Arial, Malgun Gothic, sans-serif", LYRIC_FONT_SIZE);
+  const rowRights = Array.from({ length: LYRIC_MAX_ROWS }, () => Number.NEGATIVE_INFINITY);
   const lyricY = stave.getYForLine(6) + 28;
   measure.slots.forEach((slot, slotIndex) => {
     const lyric = slot.lyric?.trim().normalize("NFC");
@@ -366,23 +361,35 @@ function drawLyricLane(
       return;
     }
 
-    const x = noteXBySlot.get(slotIndex) ?? slotToX(stave, slotIndex);
+    const x = slotToX(stave, slotIndex);
     const width = lyricVisualWidth(lyric);
     const left = x - width / 2;
     const right = left + width;
-    if (left < lastRight + LYRIC_MIN_GAP_PX) {
-      return;
-    }
+    const row = firstAvailableLyricRow(rowRights, left);
+    const y = lyricY + row * LYRIC_ROW_GAP_PX;
 
-    context.fillText(lyric, left, lyricY);
-    lastRight = right;
+    context.fillText(lyric, left, y);
+    rowRights[row] = right;
   });
   context.restore();
 }
 
 function lyricVisualWidth(text: string): number {
-  const hangulCount = Array.from(text).filter(isHangulSyllable).length;
-  return text.length * 8 + hangulCount * LYRIC_HANGUL_PADDING_PX;
+  return Array.from(text).reduce((width, char) => {
+    if (isHangulSyllable(char)) {
+      return width + LYRIC_FONT_SIZE;
+    }
+    return width + 7;
+  }, 0);
+}
+
+function firstAvailableLyricRow(rowRights: number[], left: number): number {
+  const row = rowRights.findIndex((right) => left >= right + LYRIC_MIN_GAP_PX);
+  if (row >= 0) {
+    return row;
+  }
+
+  return rowRights.indexOf(Math.min(...rowRights));
 }
 
 function isHangulSyllable(char: string): boolean {
@@ -393,7 +400,7 @@ function isHangulSyllable(char: string): boolean {
 function slotToX(stave: Stave, slot: number): number {
   const startX = stave.getNoteStartX();
   const endX = stave.getNoteEndX();
-  return startX + (slot / SLOTS_PER_MEASURE) * (endX - startX);
+  return startX + ((slot + 0.5) / SLOTS_PER_MEASURE) * (endX - startX);
 }
 
 function drawMeasureNumber(

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,6 +1,8 @@
 import type { AnalysisJobStatus, AnalysisResult } from "./types";
 
 const ANALYZE_JOBS_URL = process.env.NEXT_PUBLIC_ANALYZE_JOBS_URL ?? "/api/analyze/jobs";
+const ANALYZE_YOUTUBE_JOBS_URL =
+  process.env.NEXT_PUBLIC_ANALYZE_YOUTUBE_JOBS_URL ?? "/api/analyze/youtube/jobs";
 const POLL_INTERVAL_MS = 2000;
 const MAX_JOB_WAIT_MS = 60 * 60 * 1000;
 
@@ -22,6 +24,26 @@ export async function analyzeAudio(file: File, options: AnalyzeOptions = {}): Pr
   });
 
   await throwIfNotOk(response, "Could not start analysis.");
+
+  const job = (await response.json()) as AnalysisJobStatus;
+  options.onStatus?.(job);
+
+  return pollAnalysisJob(job.job_id, options);
+}
+
+export async function analyzeYouTube(youtubeUrl: string, options: AnalyzeOptions = {}): Promise<AnalysisResult> {
+  const formData = new FormData();
+  formData.append("youtube_url", youtubeUrl);
+  if (options.enableLyrics !== undefined) {
+    formData.append("enable_lyrics", String(options.enableLyrics));
+  }
+
+  const response = await fetch(ANALYZE_YOUTUBE_JOBS_URL, {
+    method: "POST",
+    body: formData,
+  });
+
+  await throwIfNotOk(response, "Could not start YouTube analysis.");
 
   const job = (await response.json()) as AnalysisJobStatus;
   options.onStatus?.(job);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       BEATLY_UPLOAD_DIR: /tmp/beatly/uploads
       BEATLY_SEPARATED_DIR: /tmp/beatly/separated
       BEATLY_ANALYSIS_CACHE_DIR: /tmp/beatly/analysis-cache
+      BEATLY_YOUTUBE_DIR: /tmp/beatly/youtube
       BEATLY_USE_STUBS: "false"
       BEATLY_ENABLE_LYRICS: "true"
       BEATLY_FORCE_VOCALS_FOR_LYRICS: "true"


### PR DESCRIPTION
## 변경 내용 요약
- MP3 업로드 외에 YouTube 링크로 분석 작업을 시작할 수 있게 했습니다.
- YouTube 한국어 캡션이 있으면 Lyric Lane 가사로 우선 사용하고, 없으면 기존 Demucs/Whisper 경로로 처리합니다.
- 웹 화면에 MP3 업로드와 YouTube 링크 입력을 전환하는 소스 선택 UI를 추가했습니다.
- 반복되는 롤링 캡션을 정리하고, 가까운 가사를 두 줄 Lyric Lane에 배치해 누락을 줄였습니다.

## 변경 이유
- 사용자가 로컬 MP3 파일 없이도 YouTube 링크에서 드럼 악보 생성을 시작할 수 있어야 합니다.
- YouTube 캡션이 있는 경우 Whisper 비용과 대기 시간을 줄이면서 단어 시간축을 보존할 수 있습니다.
- 자동 캡션은 이전 문구를 겹쳐 보여주는 경우가 있어 그대로 쓰면 가사가 중복되거나 너무 조밀하게 렌더링됩니다.

## 주요 변경 사항
- API에 `/analyze/youtube/jobs` 작업 생성 엔드포인트를 추가했습니다.
- `yt-dlp`로 YouTube 메타데이터, 오디오, 캡션을 가져오는 `youtube_source` 서비스를 추가했습니다.
- 캡션은 한국어 트랙을 우선 선택하고 VTT/JSON3 형식을 LyricWord 타임라인으로 변환합니다.
- 롤링 캡션의 이전 단위와 겹치는 앞부분을 제거하고, 캡션 레이아웃 버전을 캐시 키에 포함했습니다.
- 캡션 기반 가사도 기존 16분 슬롯 병합과 독립 Lyric Lane 렌더링 경로를 그대로 사용합니다.
- DrumSheet Lyric Lane은 가까운 가사를 2개 행으로 분산해 표시합니다.
- 웹 클라이언트는 YouTube 작업 API 프록시를 통해 작업을 시작하고 기존 작업 상태 폴링을 재사용합니다.
- 이전 흐름: 사용자는 오디오 파일만 업로드할 수 있었습니다.
- 변경 후 흐름: 사용자는 MP3 업로드 또는 YouTube 링크 중 하나를 선택해 같은 악보 결과를 받을 수 있습니다.

## 테스트 방법
- `git diff --check`
- `git diff --cached --check`
- `npm --workspace apps/web run lint`
- `npm --workspace apps/web run build`
- `docker compose config`
- `py -3 harness\beatly_quality_harness.py`는 실행하지 못했습니다. 이 환경에는 `py`, `python`, `python3` 명령이 없고 `harness\beatly_quality_harness.py` 파일도 없습니다.
