### PR TITLE
[FULL] 싱크 재생과 캡션 가사 타이밍 정렬

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -19,6 +19,7 @@ from app.models import AnalysisJobStatus, AnalysisResult, LyricWord
 from app.services.audio_preprocess import AudioPreprocessError, prepare_audio_for_analysis
 from app.services.drum_analysis import analyze_drum_track
 from app.services.drum_separation import DrumSeparationError, separate_stems_with_demucs
+from app.services.lyric_alignment import ALIGNMENT_VERSION, align_caption_words_to_whisper_timing
 from app.services.lyrics import preload_whisper_model, transcribe_words_with_whisper
 from app.services.notation import TICKS_PER_QUARTER, build_engraved_measures, build_midi_tick_list
 from app.services.score_merge import build_lyric_lane, merge_drums_and_lyrics
@@ -187,7 +188,7 @@ def _run_youtube_analysis_job(
                 youtube_source.caption_source,
                 len(caption_words),
             )
-            _update_job(job_id, status="running", detail="Using YouTube captions for lyrics.")
+            _update_job(job_id, status="running", detail="Aligning YouTube captions with Whisper timing.")
         else:
             logger.info("[%s] youtube captions unavailable; using existing lyric extraction path", job_id)
             if should_extract_lyrics:
@@ -200,6 +201,7 @@ def _run_youtube_analysis_job(
             should_extract_lyrics and not caption_words,
             progress=lambda detail: _update_job(job_id, status="running", detail=detail),
             provided_words=caption_words,
+            align_provided_lyrics_with_whisper=bool(caption_words),
             lyric_source_key=youtube_source.lyric_cache_key,
         )
     except YouTubeSourceError as exc:
@@ -221,6 +223,7 @@ def _run_analysis(
     should_extract_lyrics: bool,
     progress: Callable[[str], None] | None = None,
     provided_words: list[LyricWord] | None = None,
+    align_provided_lyrics_with_whisper: bool = False,
     lyric_source_key: str | None = None,
 ) -> AnalysisResult:
     settings = get_settings()
@@ -229,19 +232,22 @@ def _run_analysis(
     upload_hash = _file_sha256(upload_path)
     has_provided_lyrics = bool(provided_words)
     needs_whisper_lyrics = should_extract_lyrics and not has_provided_lyrics
+    needs_whisper_alignment = has_provided_lyrics and align_provided_lyrics_with_whisper
+    needs_whisper_timing = needs_whisper_lyrics or needs_whisper_alignment
     has_any_lyrics = should_extract_lyrics or has_provided_lyrics
     demucs_mode = _demucs_mode_for_request(
         settings.demucs_mode,
-        needs_whisper_lyrics,
+        needs_whisper_timing,
         settings.force_vocals_for_lyrics,
     )
-    whisper_model = _korean_whisper_model(settings.whisper_model) if needs_whisper_lyrics else settings.whisper_model
+    whisper_model = _korean_whisper_model(settings.whisper_model) if needs_whisper_timing else settings.whisper_model
     cache_key = _analysis_cache_key(
         upload_hash,
         has_any_lyrics,
         demucs_mode,
         whisper_model,
         settings,
+        alignment_mode=ALIGNMENT_VERSION if needs_whisper_alignment else None,
         lyric_source_key=lyric_source_key,
     )
     if cached_result := _load_cached_analysis(settings.analysis_cache_dir, cache_key):
@@ -250,7 +256,7 @@ def _run_analysis(
         return cached_result
 
     if (
-        needs_whisper_lyrics
+        needs_whisper_timing
         and settings.whisper_engine.strip().lower() in {"faster-whisper", "faster_whisper", "ctranslate2", "ct2"}
     ):
         _report_progress(progress, "Preparing Korean lyric model cache.")
@@ -284,7 +290,7 @@ def _run_analysis(
         stems.drums,
         stems.vocals,
         settings.separated_dir / upload_path.stem / "prepared",
-        include_vocals=needs_whisper_lyrics,
+        include_vocals=needs_whisper_timing,
     )
     logger.info("[%s] audio preprocessing finished in %.1fs", request_id, time.perf_counter() - step_started)
 
@@ -299,7 +305,41 @@ def _run_analysis(
         len(drum_events),
     )
 
-    if has_provided_lyrics:
+    if has_provided_lyrics and needs_whisper_alignment:
+        step_started = time.perf_counter()
+        _report_progress(progress, "Aligning YouTube captions to vocal timing with Whisper.")
+        logger.info(
+            "[%s] whisper timing alignment started engine=%s model=%s device=%s compute_type=%s beam_size=%d language=ko word_timestamps=True",
+            request_id,
+            settings.whisper_engine,
+            whisper_model,
+            settings.whisper_device,
+            settings.whisper_compute_type,
+            settings.whisper_beam_size,
+        )
+        whisper_words = transcribe_words_with_whisper(
+            prepared_audio.vocals,
+            model_name=whisper_model,
+            engine=settings.whisper_engine,
+            device=settings.whisper_device,
+            compute_type=settings.whisper_compute_type,
+            beam_size=settings.whisper_beam_size,
+            vad_filter=settings.whisper_vad_filter,
+            download_root=settings.whisper_download_root,
+            allow_openai_fallback=settings.whisper_openai_fallback,
+            use_stub=settings.use_stubs,
+            language="ko",
+            word_timestamps=True,
+        )
+        words = align_caption_words_to_whisper_timing(provided_words or [], whisper_words, prepared_audio.vocals)
+        logger.info(
+            "[%s] caption/whisper alignment finished in %.1fs with %d caption units and %d aligned units",
+            request_id,
+            time.perf_counter() - step_started,
+            len(provided_words or []),
+            len(words),
+        )
+    elif has_provided_lyrics:
         words = sorted(provided_words, key=lambda item: (item.start, item.end))
         logger.info("[%s] lyric transcription skipped because %d caption words were provided", request_id, len(words))
     elif needs_whisper_lyrics:
@@ -446,9 +486,11 @@ def _analysis_cache_key(
     demucs_mode: str,
     whisper_model: str,
     settings: object,
+    alignment_mode: str | None = None,
     lyric_source_key: str | None = None,
 ) -> str:
     payload = {
+        "alignment_mode": alignment_mode,
         "audio_sha256": upload_hash,
         "demucs_device": getattr(settings, "demucs_device", None),
         "demucs_mode": demucs_mode,

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -65,6 +65,7 @@ class EngravedTick(BaseModel):
 class LyricSlot(BaseModel):
     slot: int
     lyric: str
+    row: int = 0
 
 
 class EngravedSlot(BaseModel):

--- a/apps/api/app/services/lyric_alignment.py
+++ b/apps/api/app/services/lyric_alignment.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import logging
+import unicodedata
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+
+import librosa
+import numpy as np
+import soundfile as sf
+
+from app.models import LyricWord
+
+logger = logging.getLogger("uvicorn.error")
+
+ALIGNMENT_VERSION = "youtube-whisper-energy-v1"
+MIN_SYLLABLE_DURATION_SECONDS = 0.04
+DEFAULT_SAMPLE_RATE = 16000
+ENERGY_HOP_LENGTH = 256
+ENERGY_FRAME_LENGTH = 1024
+
+
+@dataclass(frozen=True)
+class TimedUnit:
+    text: str
+    start: float
+    end: float
+
+
+def align_caption_words_to_whisper_timing(
+    caption_words: list[LyricWord],
+    whisper_words: list[LyricWord],
+    vocals_audio_path: Path,
+) -> list[LyricWord]:
+    """Map clean YouTube lyric text onto Whisper timing anchors.
+
+    YouTube captions usually provide better Korean spelling but only coarse cue
+    timing. Whisper provides less reliable text but useful word timing. This
+    function keeps the YouTube text and replaces its timing with a forced,
+    monotonic alignment against Whisper's timestamped vocal units.
+    """
+    caption_units = _caption_units(caption_words)
+    if not caption_units:
+        return []
+
+    timing_units = _whisper_timing_units(whisper_words, vocals_audio_path)
+    if not timing_units:
+        logger.warning("No Whisper timing units available; using caption cue timing as fallback")
+        return _fallback_caption_timing(caption_units)
+
+    caption_keys = [_alignment_key(unit.text) for unit in caption_units]
+    timing_keys = [_alignment_key(unit.text) for unit in timing_units]
+    matcher = SequenceMatcher(a=caption_keys, b=timing_keys, autojunk=False)
+
+    aligned: list[LyricWord] = []
+    for tag, caption_start, caption_end, timing_start, timing_end in matcher.get_opcodes():
+        caption_slice = caption_units[caption_start:caption_end]
+        timing_slice = timing_units[timing_start:timing_end]
+        if tag == "insert":
+            continue
+        if tag == "equal":
+            aligned.extend(_pair_equal_units(caption_slice, timing_slice))
+            continue
+        if tag in {"replace", "delete"}:
+            aligned.extend(_map_caption_range_to_timing(caption_slice, timing_slice, aligned, timing_units, timing_end))
+
+    if not aligned:
+        return _fallback_caption_timing(caption_units)
+    return _sanitize_aligned_words(aligned)
+
+
+def _caption_units(words: list[LyricWord]) -> list[TimedUnit]:
+    units: list[TimedUnit] = []
+    for word in words:
+        text = unicodedata.normalize("NFC", word.word.strip())
+        if not text:
+            continue
+        units.append(TimedUnit(text=text, start=float(word.start), end=float(word.end)))
+    return units
+
+
+def _whisper_timing_units(words: list[LyricWord], vocals_audio_path: Path) -> list[TimedUnit]:
+    energy = _load_vocal_energy(vocals_audio_path)
+    units: list[TimedUnit] = []
+    for word in words:
+        text = unicodedata.normalize("NFC", word.word.strip())
+        if not text:
+            continue
+        expanded = _expand_text_units(text)
+        if not expanded:
+            continue
+        if len(expanded) == 1:
+            units.append(TimedUnit(text=expanded[0], start=float(word.start), end=float(word.end)))
+            continue
+        units.extend(_split_word_by_energy(expanded, float(word.start), float(word.end), energy))
+    return _sanitize_timed_units(units)
+
+
+def _load_vocal_energy(audio_path: Path) -> tuple[np.ndarray, np.ndarray]:
+    try:
+        audio, sr = sf.read(audio_path, dtype="float32", always_2d=False)
+    except Exception:
+        logger.warning("Could not load vocal energy from %s; using even Whisper word splits", audio_path)
+        return np.asarray([], dtype=np.float32), np.asarray([], dtype=np.float32)
+
+    if audio.ndim > 1:
+        audio = np.mean(audio, axis=1)
+    if sr != DEFAULT_SAMPLE_RATE:
+        audio = librosa.resample(np.asarray(audio, dtype=np.float32), orig_sr=sr, target_sr=DEFAULT_SAMPLE_RATE)
+        sr = DEFAULT_SAMPLE_RATE
+    if audio.size < ENERGY_FRAME_LENGTH:
+        return np.asarray([], dtype=np.float32), np.asarray([], dtype=np.float32)
+
+    rms = librosa.feature.rms(y=audio, frame_length=ENERGY_FRAME_LENGTH, hop_length=ENERGY_HOP_LENGTH)[0]
+    times = librosa.frames_to_time(np.arange(rms.size), sr=sr, hop_length=ENERGY_HOP_LENGTH)
+    return np.asarray(times, dtype=np.float32), np.asarray(rms, dtype=np.float32)
+
+
+def _split_word_by_energy(
+    units: list[str],
+    start: float,
+    end: float,
+    energy: tuple[np.ndarray, np.ndarray],
+) -> list[TimedUnit]:
+    duration = max(end - start, MIN_SYLLABLE_DURATION_SECONDS * len(units))
+    fallback_step = duration / len(units)
+    peaks = _energy_peaks_in_regions(start, start + duration, len(units), energy)
+    if len(peaks) != len(units):
+        peaks = [start + index * fallback_step for index in range(len(units))]
+
+    output: list[TimedUnit] = []
+    for index, unit in enumerate(units):
+        unit_start = peaks[index]
+        if index + 1 < len(peaks):
+            unit_end = max(unit_start + MIN_SYLLABLE_DURATION_SECONDS, peaks[index + 1])
+        else:
+            unit_end = max(unit_start + MIN_SYLLABLE_DURATION_SECONDS, start + duration)
+        output.append(TimedUnit(text=unit, start=unit_start, end=unit_end))
+    return output
+
+
+def _energy_peaks_in_regions(
+    start: float,
+    end: float,
+    count: int,
+    energy: tuple[np.ndarray, np.ndarray],
+) -> list[float]:
+    times, rms = energy
+    if count <= 0 or times.size == 0 or rms.size == 0:
+        return []
+
+    region_edges = np.linspace(start, end, count + 1)
+    peaks: list[float] = []
+    for index in range(count):
+        region_start = float(region_edges[index])
+        region_end = float(region_edges[index + 1])
+        mask = (times >= region_start) & (times < region_end)
+        if not np.any(mask):
+            peaks.append(region_start)
+            continue
+        region_times = times[mask]
+        region_rms = rms[mask]
+        peak_index = int(np.argmax(region_rms))
+        peaks.append(float(region_times[peak_index]))
+    return peaks
+
+
+def _pair_equal_units(caption_units: list[TimedUnit], timing_units: list[TimedUnit]) -> list[LyricWord]:
+    return [
+        _lyric_word(caption.text, timing.start, timing.end)
+        for caption, timing in zip(caption_units, timing_units)
+    ]
+
+
+def _map_caption_range_to_timing(
+    caption_units: list[TimedUnit],
+    timing_units: list[TimedUnit],
+    already_aligned: list[LyricWord],
+    all_timing_units: list[TimedUnit],
+    next_timing_index: int,
+) -> list[LyricWord]:
+    if not caption_units:
+        return []
+    if timing_units:
+        return _spread_caption_units_over_timing(caption_units, timing_units)
+
+    previous_end = already_aligned[-1].end if already_aligned else caption_units[0].start
+    next_start = all_timing_units[next_timing_index].start if next_timing_index < len(all_timing_units) else caption_units[-1].end
+    if next_start <= previous_end:
+        next_start = previous_end + MIN_SYLLABLE_DURATION_SECONDS * len(caption_units)
+    return _spread_caption_units_over_span(caption_units, previous_end, next_start)
+
+
+def _spread_caption_units_over_timing(caption_units: list[TimedUnit], timing_units: list[TimedUnit]) -> list[LyricWord]:
+    if len(caption_units) == len(timing_units):
+        return _pair_equal_units(caption_units, timing_units)
+
+    span_start = timing_units[0].start
+    span_end = max(timing_units[-1].end, span_start + MIN_SYLLABLE_DURATION_SECONDS * len(caption_units))
+    return _spread_caption_units_over_span(caption_units, span_start, span_end)
+
+
+def _spread_caption_units_over_span(caption_units: list[TimedUnit], start: float, end: float) -> list[LyricWord]:
+    duration = max(end - start, MIN_SYLLABLE_DURATION_SECONDS * len(caption_units))
+    step = duration / len(caption_units)
+    return [
+        _lyric_word(unit.text, start + index * step, start + (index + 1) * step)
+        for index, unit in enumerate(caption_units)
+    ]
+
+
+def _fallback_caption_timing(caption_units: list[TimedUnit]) -> list[LyricWord]:
+    return _sanitize_aligned_words([
+        _lyric_word(unit.text, unit.start, unit.end)
+        for unit in caption_units
+    ])
+
+
+def _sanitize_timed_units(units: list[TimedUnit]) -> list[TimedUnit]:
+    output: list[TimedUnit] = []
+    previous_start = 0.0
+    for unit in sorted(units, key=lambda item: (item.start, item.end)):
+        text = unicodedata.normalize("NFC", unit.text.strip())
+        if not text:
+            continue
+        start = max(previous_start, float(unit.start))
+        end = max(start + MIN_SYLLABLE_DURATION_SECONDS, float(unit.end))
+        output.append(TimedUnit(text=text, start=start, end=end))
+        previous_start = start
+    return output
+
+
+def _sanitize_aligned_words(words: list[LyricWord]) -> list[LyricWord]:
+    output: list[LyricWord] = []
+    previous_start = 0.0
+    for word in sorted(words, key=lambda item: (item.start, item.end)):
+        text = unicodedata.normalize("NFC", word.word.strip())
+        if not text:
+            continue
+        start = max(previous_start, float(word.start))
+        end = max(start + MIN_SYLLABLE_DURATION_SECONDS, float(word.end))
+        output.append(_lyric_word(text, start, end))
+        previous_start = start
+    return output
+
+
+def _expand_text_units(text: str) -> list[str]:
+    units: list[str] = []
+    buffer: list[str] = []
+
+    def flush_buffer() -> None:
+        if not buffer:
+            return
+        token = unicodedata.normalize("NFC", "".join(buffer).strip(".,!?;:\"'()[]{}<>“”‘’"))
+        if token:
+            units.append(token)
+        buffer.clear()
+
+    for char in unicodedata.normalize("NFC", text):
+        if _is_hangul_syllable(char):
+            flush_buffer()
+            units.append(char)
+            continue
+        if char.isspace() or unicodedata.category(char).startswith("P"):
+            flush_buffer()
+            continue
+        buffer.append(char)
+
+    flush_buffer()
+    return units
+
+
+def _alignment_key(text: str) -> str:
+    return "".join(char for char in unicodedata.normalize("NFC", text).lower() if char.isalnum())
+
+
+def _lyric_word(word: str, start: float, end: float) -> LyricWord:
+    safe_start = round(max(0.0, start), 3)
+    safe_end = round(max(safe_start + MIN_SYLLABLE_DURATION_SECONDS, end), 3)
+    return LyricWord(word=unicodedata.normalize("NFC", word.strip()), start=safe_start, end=safe_end)
+
+
+def _is_hangul_syllable(char: str) -> bool:
+    return 0xAC00 <= ord(char) <= 0xD7A3

--- a/apps/api/app/services/notation.py
+++ b/apps/api/app/services/notation.py
@@ -666,24 +666,21 @@ def _rebalance_voice_to_4_4(ticks: list[EngravedTick], voice: int) -> list[Engra
 
 
 def _sanitize_lyric_slots(slots: list[LyricSlot]) -> list[LyricSlot]:
-    by_slot: dict[int, str] = {}
-    occupied: set[int] = set()
+    output: list[LyricSlot] = []
+    occupied: set[tuple[int, int]] = set()
     for slot in slots:
         index = min(SLOTS_PER_MEASURE - 1, max(0, slot.slot))
+        row = min(1, max(0, slot.row))
         text = unicodedata.normalize("NFC", slot.lyric.strip())
         if not text:
             continue
-        while index in occupied and index < SLOTS_PER_MEASURE - 1:
-            index += 1
-        if index in occupied:
-            continue
-        occupied.add(index)
-        by_slot[index] = text
+        while (index, row) in occupied and row < 1:
+            row += 1
+        position = (index, row)
+        occupied.add(position)
+        output.append(LyricSlot(slot=index, lyric=text, row=row))
 
-    return [
-        LyricSlot(slot=slot, lyric=lyric)
-        for slot, lyric in sorted(by_slot.items())
-    ]
+    return sorted(output, key=lambda slot: (slot.slot, slot.row, slot.lyric))
 
 
 def _engraved_slots_from_lyric_slots(lyric_slots: list[LyricSlot]) -> list[EngravedSlot]:

--- a/apps/api/app/services/score_merge.py
+++ b/apps/api/app/services/score_merge.py
@@ -4,6 +4,10 @@ import unicodedata
 
 from app.models import DrumEvent, LyricSlot, LyricWord, ScoreEvent
 
+MAX_LYRIC_SHIFT_SECONDS = 0.2
+LYRIC_LANE_ROWS = 2
+SLOTS_PER_MEASURE = 16
+
 
 def merge_drums_and_lyrics(
     drum_events: list[DrumEvent],
@@ -29,34 +33,45 @@ def merge_drums_and_lyrics(
 def build_lyric_lane(words: list[LyricWord], bpm: float, measure_count: int) -> dict[int, list[LyricSlot]]:
     beat_seconds = 60 / max(bpm, 1)
     measure_seconds = beat_seconds * 4
-    slot_seconds = measure_seconds / 16
-    lane: dict[int, dict[int, str]] = {measure: {} for measure in range(1, measure_count + 1)}
-    occupied_slots: set[int] = set()
-    total_slots = max(16, measure_count * 16)
+    slot_seconds = measure_seconds / SLOTS_PER_MEASURE
+    lane: dict[int, list[LyricSlot]] = {measure: [] for measure in range(1, measure_count + 1)}
+    occupied_positions: set[tuple[int, int]] = set()
+    max_shift_slots = max(0, int(MAX_LYRIC_SHIFT_SECONDS // slot_seconds))
 
     for word in sorted(words, key=lambda item: item.start):
         text = unicodedata.normalize("NFC", word.word.strip())
         if not text:
             continue
-        absolute_slot = max(0, int(word.start // slot_seconds))
-        while absolute_slot in occupied_slots:
-            absolute_slot += 1
-        if absolute_slot >= total_slots:
-            total_slots = absolute_slot + 1
-
-        occupied_slots.add(absolute_slot)
-        measure_index = absolute_slot // 16
-        slot = absolute_slot % 16
+        preferred_slot = max(0, int(word.start // slot_seconds))
+        absolute_slot, row = _place_lyric_slot(preferred_slot, occupied_positions, max_shift_slots)
+        occupied_positions.add((absolute_slot, row))
+        measure_index = absolute_slot // SLOTS_PER_MEASURE
+        slot = absolute_slot % SLOTS_PER_MEASURE
         measure_number = measure_index + 1
-        lane.setdefault(measure_number, {})[slot] = text
+        lane.setdefault(measure_number, []).append(LyricSlot(slot=slot, lyric=text, row=row))
 
     return {
-        measure: [
-            LyricSlot(slot=slot, lyric=lyric)
-            for slot, lyric in sorted(slots.items())
-        ]
+        measure: sorted(slots, key=lambda slot: (slot.slot, slot.row, slot.lyric))
         for measure, slots in sorted(lane.items())
     }
+
+
+def _place_lyric_slot(
+    preferred_slot: int,
+    occupied_positions: set[tuple[int, int]],
+    max_shift_slots: int,
+) -> tuple[int, int]:
+    for offset in range(0, max_shift_slots + 1):
+        candidate_slot = preferred_slot + offset
+        for row in range(LYRIC_LANE_ROWS):
+            if (candidate_slot, row) not in occupied_positions:
+                return candidate_slot, row
+
+    for row in range(LYRIC_LANE_ROWS):
+        if (preferred_slot, row) not in occupied_positions:
+            return preferred_slot, row
+
+    return preferred_slot, 0
 
 
 def word_at_slot_time(words: list[LyricWord], slot_time: float) -> str | None:

--- a/apps/api/app/services/youtube_source.py
+++ b/apps/api/app/services/youtube_source.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 import unicodedata
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
@@ -16,8 +17,12 @@ from app.models import LyricWord
 logger = logging.getLogger("uvicorn.error")
 
 CAPTION_MIN_DURATION_SECONDS = 0.1
-CAPTION_LAYOUT_VERSION = "youtube-whisper-alignment-v1"
+CAPTION_LAYOUT_VERSION = "youtube-whisper-alignment-v2"
 CAPTION_ROLLING_OVERLAP_SECONDS = 0.75
+CAPTION_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+CAPTION_DOWNLOAD_TIMEOUT_SECONDS = 60
+CAPTION_FORMAT_PRIORITY = ("json3", "vtt", "srv3", "srv2", "srv1", "ttml", "xml")
+CAPTION_LANGUAGE_PRIORITY = ("ko", "en")
 USER_AGENT = "Beatly/0.1 (+https://localhost)"
 YOUTUBE_HOST_PATTERN = re.compile(r"(youtube\.com|youtu\.be|music\.youtube\.com)", re.IGNORECASE)
 VTT_TIME_PATTERN = re.compile(
@@ -108,6 +113,7 @@ def _extract_info(url: str) -> dict[str, Any]:
     options: dict[str, Any] = {
         "quiet": True,
         "no_warnings": True,
+        "listsubtitles": True,
         "noplaylist": True,
         "skip_download": True,
         "retries": 3,
@@ -162,15 +168,7 @@ def _download_audio(url: str, output_dir: Path) -> Path:
 
 
 def _fetch_best_caption(info: dict[str, Any]) -> tuple[str, str, str] | None:
-    candidates = [
-        ("official", info.get("subtitles") or {}),
-        ("auto", info.get("automatic_captions") or {}),
-    ]
-    for source_kind, tracks in candidates:
-        selected = _select_caption_track(tracks)
-        if selected is None:
-            continue
-        language, caption_format = selected
+    for source_kind, language, caption_format in _iter_caption_candidates(info):
         caption_url = str(caption_format.get("url") or "")
         caption_ext = str(caption_format.get("ext") or "").lower()
         if not caption_url:
@@ -178,48 +176,101 @@ def _fetch_best_caption(info: dict[str, Any]) -> tuple[str, str, str] | None:
         try:
             payload = _download_text(caption_url)
         except Exception:
-            logger.exception("Could not fetch YouTube caption language=%s source=%s", language, source_kind)
+            logger.exception(
+                "Could not fetch YouTube caption source=%s language=%s format=%s; trying next format",
+                source_kind,
+                language,
+                caption_ext,
+            )
+            continue
+        cues = _parse_caption_payload(payload, caption_ext)
+        if not cues:
+            logger.warning(
+                "YouTube caption source=%s language=%s format=%s had no parseable cues; trying next format",
+                source_kind,
+                language,
+                caption_ext,
+            )
             continue
         return f"{source_kind}:{language}", payload, caption_ext
     return None
 
 
-def _select_caption_track(tracks: dict[str, list[dict[str, Any]]]) -> tuple[str, dict[str, Any]] | None:
-    if not tracks:
-        return None
-
-    languages = list(tracks.keys())
-    preferred_languages = [
-        language for language in languages if language.lower() in {"ko", "ko-kr"} or language.lower().startswith("ko-")
-    ]
-    preferred_languages.extend(language for language in languages if language not in preferred_languages)
-
-    for language in preferred_languages:
-        formats = tracks.get(language) or []
-        selected_format = _select_caption_format(formats)
-        if selected_format is not None:
-            return language, selected_format
-    return None
+def _iter_caption_candidates(info: dict[str, Any]) -> list[tuple[str, str, dict[str, Any]]]:
+    official_tracks = info.get("subtitles") or {}
+    automatic_tracks = info.get("automatic_captions") or {}
+    candidates: list[tuple[str, str, dict[str, Any]]] = []
+    candidates.extend(_caption_candidates_for_tracks("official", official_tracks))
+    candidates.extend(_caption_candidates_for_tracks("auto", automatic_tracks))
+    return candidates
 
 
-def _select_caption_format(formats: list[dict[str, Any]]) -> dict[str, Any] | None:
-    for preferred_ext in ("vtt", "json3", "srv3", "ttml"):
-        for caption_format in formats:
-            if str(caption_format.get("ext") or "").lower() == preferred_ext:
-                return caption_format
-    return formats[0] if formats else None
+def _caption_candidates_for_tracks(
+    source_kind: str,
+    tracks: dict[str, list[dict[str, Any]]],
+) -> list[tuple[str, str, dict[str, Any]]]:
+    candidates: list[tuple[str, str, dict[str, Any]]] = []
+    for language in _ordered_caption_languages(tracks):
+        for caption_format in _ordered_caption_formats(tracks.get(language) or []):
+            candidates.append((source_kind, language, caption_format))
+    return candidates
+
+
+def _ordered_caption_languages(tracks: dict[str, list[dict[str, Any]]]) -> list[str]:
+    languages = [language for language in tracks if _is_supported_caption_language(language)]
+    return sorted(languages, key=_caption_language_rank)
+
+
+def _is_supported_caption_language(language: str) -> bool:
+    normalized = language.lower()
+    return any(normalized == code or normalized.startswith(f"{code}-") for code in CAPTION_LANGUAGE_PRIORITY)
+
+
+def _caption_language_rank(language: str) -> tuple[int, str]:
+    normalized = language.lower()
+    for index, code in enumerate(CAPTION_LANGUAGE_PRIORITY):
+        if normalized == code or normalized.startswith(f"{code}-"):
+            return index, normalized
+    return len(CAPTION_LANGUAGE_PRIORITY), normalized
+
+
+def _ordered_caption_formats(formats: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: dict[str, dict[str, Any]] = {}
+    for caption_format in formats:
+        key = str(caption_format.get("url") or id(caption_format))
+        deduped.setdefault(key, caption_format)
+
+    def format_rank(caption_format: dict[str, Any]) -> tuple[int, str]:
+        ext = str(caption_format.get("ext") or "").lower()
+        try:
+            index = CAPTION_FORMAT_PRIORITY.index(ext)
+        except ValueError:
+            index = len(CAPTION_FORMAT_PRIORITY)
+        return index, ext
+
+    return sorted(deduped.values(), key=format_rank)
 
 
 def _download_text(url: str) -> str:
     request = Request(url, headers={"User-Agent": USER_AGENT})
-    with urlopen(request, timeout=20) as response:
+    chunks: list[bytes] = []
+    with urlopen(request, timeout=CAPTION_DOWNLOAD_TIMEOUT_SECONDS) as response:
         charset = response.headers.get_content_charset() or "utf-8"
-        return response.read().decode(charset, errors="replace")
+        while True:
+            chunk = response.read(CAPTION_DOWNLOAD_CHUNK_BYTES)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks).decode(charset, errors="replace")
 
 
 def _parse_caption_payload(payload: str, caption_ext: str) -> list[CaptionCue]:
     if caption_ext == "json3" or payload.lstrip().startswith("{"):
         return _parse_json3_captions(payload)
+    if caption_ext in {"srv1", "srv2", "srv3"} or payload.lstrip().startswith("<transcript"):
+        return _parse_srv_captions(payload)
+    if caption_ext in {"ttml", "xml"} or payload.lstrip().startswith("<tt"):
+        return _parse_ttml_captions(payload)
     return _parse_vtt_captions(payload)
 
 
@@ -262,6 +313,64 @@ def _parse_vtt_captions(payload: str) -> list[CaptionCue]:
         if text.strip():
             cues.append(CaptionCue(start=start, end=max(end, start + CAPTION_MIN_DURATION_SECONDS), text=text))
     return cues
+
+
+def _parse_srv_captions(payload: str) -> list[CaptionCue]:
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError:
+        return []
+
+    cues: list[CaptionCue] = []
+    for element in root.iter():
+        if _xml_tag_name(element.tag) != "text":
+            continue
+        raw_text = "".join(element.itertext())
+        if not raw_text.strip():
+            continue
+        start = _xml_time_to_seconds(element.attrib.get("start", "0"))
+        duration = _xml_time_to_seconds(element.attrib.get("dur", str(CAPTION_MIN_DURATION_SECONDS)))
+        cues.append(CaptionCue(start=start, end=start + max(duration, CAPTION_MIN_DURATION_SECONDS), text=raw_text))
+    return cues
+
+
+def _parse_ttml_captions(payload: str) -> list[CaptionCue]:
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError:
+        return []
+
+    cues: list[CaptionCue] = []
+    for element in root.iter():
+        if _xml_tag_name(element.tag) != "p":
+            continue
+        raw_text = " ".join(text.strip() for text in element.itertext() if text.strip())
+        if not raw_text:
+            continue
+        begin = _xml_time_to_seconds(element.attrib.get("begin", element.attrib.get("start", "0")))
+        if "end" in element.attrib:
+            end = _xml_time_to_seconds(element.attrib["end"])
+        else:
+            end = begin + _xml_time_to_seconds(element.attrib.get("dur", str(CAPTION_MIN_DURATION_SECONDS)))
+        cues.append(CaptionCue(start=begin, end=max(end, begin + CAPTION_MIN_DURATION_SECONDS), text=raw_text))
+    return cues
+
+
+def _xml_tag_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _xml_time_to_seconds(value: str) -> float:
+    raw = value.strip()
+    if not raw:
+        return 0.0
+    if raw.endswith("ms"):
+        return float(raw[:-2]) / 1000
+    if raw.endswith("s"):
+        return float(raw[:-1])
+    if ":" in raw:
+        return _parse_vtt_time(raw.replace(",", "."))
+    return float(raw)
 
 
 def _parse_vtt_time(value: str) -> float:

--- a/apps/api/app/services/youtube_source.py
+++ b/apps/api/app/services/youtube_source.py
@@ -16,7 +16,7 @@ from app.models import LyricWord
 logger = logging.getLogger("uvicorn.error")
 
 CAPTION_MIN_DURATION_SECONDS = 0.1
-CAPTION_LAYOUT_VERSION = "youtube-caption-grid-v2"
+CAPTION_LAYOUT_VERSION = "youtube-whisper-alignment-v1"
 CAPTION_ROLLING_OVERLAP_SECONDS = 0.75
 USER_AGENT = "Beatly/0.1 (+https://localhost)"
 YOUTUBE_HOST_PATTERN = re.compile(r"(youtube\.com|youtu\.be|music\.youtube\.com)", re.IGNORECASE)
@@ -302,15 +302,11 @@ def _caption_cues_to_words(cues: list[CaptionCue]) -> list[LyricWord]:
             previous_units = raw_units
             previous_end = max(previous_end, cue.end)
             continue
-        duration = max(cue.end - start_base, CAPTION_MIN_DURATION_SECONDS * len(units))
-        step = duration / len(units)
-        for index, unit in enumerate(units):
-            start = start_base + index * step
-            end = start_base + (index + 1) * step
-            words.append(_lyric_word(unit, start, end))
+        for unit in units:
+            words.append(_lyric_word(unit, start_base, cue.end))
         previous_units = raw_units
         previous_end = max(previous_end, cue.end)
-    return _sanitize_word_timeline(words)
+    return words
 
 
 def _clean_caption_text(text: str) -> str:

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -167,6 +167,89 @@ input {
   background: #fff;
 }
 
+.player-panel {
+  display: grid;
+  gap: 14px;
+  margin: 14px 0 18px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.player-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.player-kicker {
+  margin-bottom: 4px;
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.player-title {
+  max-width: 780px;
+  overflow: hidden;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.player-button {
+  min-width: 92px;
+  min-height: 40px;
+  border: 0;
+  border-radius: 8px;
+  color: #fff;
+  background: var(--accent);
+  cursor: pointer;
+}
+
+.transport-row,
+.volume-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.seek-slider {
+  flex: 1 1 360px;
+  min-width: 180px;
+}
+
+.volume-row {
+  color: var(--muted);
+}
+
+.volume-row input {
+  width: 180px;
+}
+
+.time-label {
+  min-width: 46px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.youtube-player-shell {
+  width: 320px;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #000;
+}
+
+.youtube-player-shell iframe {
+  display: block;
+  max-width: 100%;
+}
+
 .score-wrap {
   margin-top: 18px;
   overflow-x: auto;
@@ -178,6 +261,59 @@ input {
 .score-canvas {
   min-width: 920px;
   padding: 16px 12px 8px;
+}
+
+.score-board {
+  position: relative;
+  display: inline-block;
+}
+
+.score-board.seekable {
+  cursor: pointer;
+}
+
+.score-svg-layer {
+  position: relative;
+  z-index: 1;
+}
+
+.score-overlay-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.playback-slot-highlight,
+.playback-cursor,
+.playback-lyric-highlight {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.playback-slot-highlight {
+  border-radius: 4px;
+  background: rgba(14, 124, 102, 0.08);
+}
+
+.playback-cursor {
+  width: 3px;
+  border-radius: 3px;
+  background: #d92d20;
+  box-shadow: 0 0 0 1px rgba(217, 45, 32, 0.18);
+}
+
+.playback-lyric-highlight {
+  padding: 2px 5px;
+  border-radius: 6px;
+  color: #fff;
+  background: #0e7c66;
+  font-size: 12px;
+  line-height: 1.2;
+  transform-origin: center;
+  white-space: nowrap;
 }
 
 .empty {
@@ -205,6 +341,19 @@ input {
   .file-input,
   .text-input,
   .button {
+    width: 100%;
+  }
+
+  .player-header,
+  .transport-row,
+  .volume-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .player-button,
+  .seek-slider,
+  .volume-row input {
     width: 100%;
   }
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,29 +1,50 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { DrumSheet } from "@/components/DrumSheet";
+import {
+  SynchronizedScorePlayer,
+  type PlaybackSource,
+  type SynchronizedScorePlayerHandle,
+} from "@/components/SynchronizedScorePlayer";
 import { analyzeAudio, analyzeYouTube } from "@/lib/api";
 import type { AnalysisJobStatus, AnalysisResult } from "@/lib/types";
 
 type SourceType = "upload" | "youtube";
 
 export default function Home() {
+  const audioObjectUrlRef = useRef<string | null>(null);
+  const playerRef = useRef<SynchronizedScorePlayerHandle | null>(null);
   const [sourceType, setSourceType] = useState<SourceType>("upload");
   const [file, setFile] = useState<File | null>(null);
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [score, setScore] = useState<AnalysisResult | null>(null);
+  const [playbackSource, setPlaybackSource] = useState<PlaybackSource | null>(null);
+  const [audioCurrentTime, setAudioCurrentTime] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [enableLyrics, setEnableLyrics] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusText, setStatusText] = useState<string | null>(null);
 
+  useEffect(() => {
+    return () => {
+      if (audioObjectUrlRef.current) {
+        URL.revokeObjectURL(audioObjectUrlRef.current);
+      }
+    };
+  }, []);
+
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (sourceType === "upload" && !file) {
+    const submittedSourceType = sourceType;
+    const submittedFile = file;
+    const submittedYoutubeUrl = youtubeUrl.trim();
+
+    if (submittedSourceType === "upload" && !submittedFile) {
       setError("Choose an MP3, WAV, M4A, or FLAC file.");
       return;
     }
-    if (sourceType === "youtube" && !youtubeUrl.trim()) {
+    if (submittedSourceType === "youtube" && !submittedYoutubeUrl) {
       setError("Enter a YouTube link.");
       return;
     }
@@ -39,10 +60,12 @@ export default function Home() {
         },
       };
       const result =
-        sourceType === "youtube"
-          ? await analyzeYouTube(youtubeUrl.trim(), options)
-          : await analyzeAudio(file as File, options);
+        submittedSourceType === "youtube"
+          ? await analyzeYouTube(submittedYoutubeUrl, options)
+          : await analyzeAudio(submittedFile as File, options);
+      setPlaybackSourceForInput(submittedSourceType, submittedFile, submittedYoutubeUrl);
       setScore(result);
+      setAudioCurrentTime(0);
       setStatusText(null);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Analysis failed.");
@@ -50,6 +73,52 @@ export default function Home() {
       setIsLoading(false);
     }
   }
+
+  function setPlaybackSourceForInput(
+    submittedSourceType: SourceType,
+    submittedFile: File | null,
+    submittedYoutubeUrl: string,
+  ) {
+    if (audioObjectUrlRef.current) {
+      URL.revokeObjectURL(audioObjectUrlRef.current);
+      audioObjectUrlRef.current = null;
+    }
+
+    if (submittedSourceType === "upload" && submittedFile) {
+      const objectUrl = URL.createObjectURL(submittedFile);
+      audioObjectUrlRef.current = objectUrl;
+      setPlaybackSource({
+        kind: "audio",
+        title: submittedFile.name,
+        url: objectUrl,
+      });
+      return;
+    }
+
+    if (submittedSourceType === "youtube") {
+      const videoId = extractYouTubeVideoId(submittedYoutubeUrl);
+      if (!videoId) {
+        setPlaybackSource(null);
+        throw new Error("Could not read the YouTube video id for playback.");
+      }
+
+      setPlaybackSource({
+        kind: "youtube",
+        title: submittedYoutubeUrl,
+        url: submittedYoutubeUrl,
+        videoId,
+      });
+    }
+  }
+
+  const handlePlayerTimeChange = useCallback((time: number) => {
+    setAudioCurrentTime((current) => (Math.abs(current - time) >= 0.008 ? time : current));
+  }, []);
+
+  const handleScoreSeek = useCallback((time: number) => {
+    playerRef.current?.seekTo(time);
+    setAudioCurrentTime(time);
+  }, []);
 
   return (
     <main className="page">
@@ -127,7 +196,16 @@ export default function Home() {
               <span className="pill">Drum events {score.events.length}</span>
               <span className="pill">Words {score.words.length}</span>
             </div>
-            <DrumSheet score={score} />
+            {playbackSource ? (
+              <SynchronizedScorePlayer
+                ref={playerRef}
+                currentTime={audioCurrentTime}
+                onTimeChange={handlePlayerTimeChange}
+                score={score}
+                source={playbackSource}
+              />
+            ) : null}
+            <DrumSheet audioCurrentTime={audioCurrentTime} onSeek={handleScoreSeek} score={score} />
           </>
         ) : (
           <div className="empty">No score generated yet.</div>
@@ -135,6 +213,30 @@ export default function Home() {
       </div>
     </main>
   );
+}
+
+function extractYouTubeVideoId(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.hostname === "youtu.be") {
+      return url.pathname.split("/").filter(Boolean)[0] ?? null;
+    }
+
+    const queryId = url.searchParams.get("v");
+    if (queryId) {
+      return queryId;
+    }
+
+    const parts = url.pathname.split("/").filter(Boolean);
+    const embedIndex = parts.findIndex((part) => part === "embed" || part === "shorts" || part === "live");
+    if (embedIndex >= 0) {
+      return parts[embedIndex + 1] ?? null;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 function formatJobStatus(status: string, detail?: string | null): string {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -23,6 +23,7 @@ export default function Home() {
   const [audioCurrentTime, setAudioCurrentTime] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [enableLyrics, setEnableLyrics] = useState(true);
+  const [showLyrics, setShowLyrics] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusText, setStatusText] = useState<string | null>(null);
 
@@ -172,6 +173,13 @@ export default function Home() {
             <button className="button" disabled={isLoading} type="submit">
               {isLoading ? "Analyzing..." : "Generate Score"}
             </button>
+            <button
+              className={showLyrics ? "source-button active" : "source-button"}
+              onClick={() => setShowLyrics((current) => !current)}
+              type="button"
+            >
+              {showLyrics ? "Hide Lyrics" : "Show Lyrics"}
+            </button>
           </div>
           <label className="option-row">
             <input
@@ -205,7 +213,12 @@ export default function Home() {
                 source={playbackSource}
               />
             ) : null}
-            <DrumSheet audioCurrentTime={audioCurrentTime} onSeek={handleScoreSeek} score={score} />
+            <DrumSheet
+              audioCurrentTime={audioCurrentTime}
+              onSeek={handleScoreSeek}
+              score={score}
+              showLyrics={showLyrics}
+            />
           </>
         ) : (
           <div className="empty">No score generated yet.</div>

--- a/apps/web/components/DrumSheet.tsx
+++ b/apps/web/components/DrumSheet.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Articulation, Formatter, Renderer, Stave, StaveNote, Voice } from "vexflow";
 import type { AnalysisResult, DrumNote, EngravedMeasure, LyricWord, MidiTickEvent, ScoreEvent } from "@/lib/types";
 
-type Props = { score: AnalysisResult };
+type Props = {
+  audioCurrentTime?: number;
+  onSeek?: (time: number) => void;
+  score: AnalysisResult;
+};
 type VoiceNumber = 1 | 2;
 type NotationEvent = Pick<
   MidiTickEvent,
@@ -14,6 +18,11 @@ type MeasureSlot = {
   voice1: NotationEvent[];
   voice2: NotationEvent[];
   lyric?: string | null;
+  lyrics: SlotLyric[];
+};
+type SlotLyric = {
+  lyric: string;
+  row: number;
 };
 type Measure = { slots: MeasureSlot[] };
 type DisplayTick = {
@@ -21,6 +30,19 @@ type DisplayTick = {
   duration: "q" | "8" | "16";
   events: NotationEvent[];
   hiddenRest?: boolean;
+};
+type MeasureLayout = {
+  bottom: number;
+  gridEndX: number;
+  gridStartX: number;
+  measure: number;
+  slotWidth: number;
+  top: number;
+};
+type PlaybackPosition = {
+  measure: number;
+  slot: number;
+  slotProgress: number;
 };
 
 const NOTE_MAP: Record<DrumNote, { key: string; voice: VoiceNumber; notehead: "normal" | "x"; order: number }> = {
@@ -44,12 +66,32 @@ const LYRIC_MIN_GAP_PX = 6;
 const LYRIC_ROW_GAP_PX = 18;
 const LYRIC_MAX_ROWS = 2;
 
-export function DrumSheet({ score }: Props) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
+export function DrumSheet({ audioCurrentTime = 0, onSeek, score }: Props) {
+  const boardRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const svgLayerRef = useRef<HTMLDivElement | null>(null);
+  const [measureLayouts, setMeasureLayouts] = useState<MeasureLayout[]>([]);
   const measures = useMemo(() => toMeasures(score), [score]);
+  const playbackPosition = useMemo(
+    () => timeToPlaybackPosition(audioCurrentTime, score.bpm, measures.length),
+    [audioCurrentTime, measures.length, score.bpm],
+  );
+  const activeLayout = measureLayouts[playbackPosition.measure - 1] ?? null;
+  const activeMeasure = measures[playbackPosition.measure - 1] ?? null;
+  const activeSlot = activeMeasure?.slots[playbackPosition.slot] ?? null;
+  const activeLyric =
+    activeSlot?.lyrics[0]?.lyric?.trim().normalize("NFC") ??
+    activeSlot?.lyric?.trim().normalize("NFC") ??
+    null;
+  const cursorX = activeLayout
+    ? activeLayout.gridStartX +
+      (playbackPosition.slotProgress / SLOTS_PER_MEASURE) * (activeLayout.gridEndX - activeLayout.gridStartX)
+    : 0;
+  const activeSlotLeft = activeLayout ? activeLayout.gridStartX + playbackPosition.slot * activeLayout.slotWidth : 0;
+  const activeSlotHeight = activeLayout ? activeLayout.bottom - activeLayout.top : 0;
 
   useEffect(() => {
-    const container = containerRef.current;
+    const container = svgLayerRef.current;
     if (!container) {
       return;
     }
@@ -63,6 +105,7 @@ export function DrumSheet({ score }: Props) {
 
     const context = renderer.getContext();
     context.setFont("Arial, Malgun Gothic, sans-serif", 12);
+    const nextLayouts: MeasureLayout[] = [];
 
     measures.forEach((measure, index) => {
       const column = index % MEASURES_PER_LINE;
@@ -104,12 +147,102 @@ export function DrumSheet({ score }: Props) {
         drawGhostSnareMarks(context, upperNotes[tickIndex], tick);
       });
       drawLyricLane(context, stave, measure);
+      nextLayouts.push(measureLayoutFromStave(stave, index + 1));
     });
+
+    setMeasureLayouts(nextLayouts);
   }, [measures]);
 
+  useEffect(() => {
+    const layout = activeLayout;
+    const board = boardRef.current;
+    const scrollContainer = scrollRef.current;
+    if (!layout || !board || !scrollContainer) {
+      return;
+    }
+
+    const centerX = layout.gridStartX + (layout.gridEndX - layout.gridStartX) / 2;
+    const targetLeft = Math.max(0, centerX - scrollContainer.clientWidth / 2);
+    scrollContainer.scrollTo({ left: targetLeft, behavior: "smooth" });
+
+    const boardRect = board.getBoundingClientRect();
+    const centerY = boardRect.top + (layout.top + layout.bottom) / 2;
+    const targetTop = Math.max(0, window.scrollY + centerY - window.innerHeight / 2);
+    if (Math.abs(targetTop - window.scrollY) > 80) {
+      window.scrollTo({ top: targetTop, behavior: "smooth" });
+    }
+  }, [activeLayout, playbackPosition.measure]);
+
+  function handleBoardClick(event: React.MouseEvent<HTMLDivElement>) {
+    if (!onSeek || !boardRef.current) {
+      return;
+    }
+
+    const rect = boardRef.current.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const layout = findMeasureLayoutAtPoint(measureLayouts, x, y);
+    if (!layout) {
+      return;
+    }
+
+    const beatSeconds = 60 / Math.max(score.bpm || 120, 1);
+    const measureSeconds = beatSeconds * 4;
+    const fraction = clamp((x - layout.gridStartX) / (layout.gridEndX - layout.gridStartX), 0, 1);
+    onSeek((layout.measure - 1) * measureSeconds + fraction * measureSeconds);
+  }
+
   return (
-    <div className="score-wrap" aria-label="Drum sheet with lyrics">
-      <div className="score-canvas" ref={containerRef} />
+    <div className="score-wrap" ref={scrollRef} aria-label="Drum sheet with synchronized playback">
+      <div className="score-canvas">
+        <div
+          className={onSeek ? "score-board seekable" : "score-board"}
+          onClick={handleBoardClick}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              if (onSeek && activeLayout) {
+                const beatSeconds = 60 / Math.max(score.bpm || 120, 1);
+                onSeek((activeLayout.measure - 1) * beatSeconds * 4);
+              }
+            }
+          }}
+          ref={boardRef}
+          role={onSeek ? "button" : undefined}
+          tabIndex={onSeek ? 0 : undefined}
+        >
+          <div className="score-svg-layer" ref={svgLayerRef} />
+          {activeLayout ? (
+            <div className="score-overlay-layer" aria-hidden="true">
+              <div
+                className="playback-slot-highlight"
+                style={{
+                  height: activeSlotHeight,
+                  transform: `translate(${activeSlotLeft}px, ${activeLayout.top}px)`,
+                  width: activeLayout.slotWidth,
+                }}
+              />
+              <div
+                className="playback-cursor"
+                style={{
+                  height: activeSlotHeight,
+                  transform: `translate(${cursorX}px, ${activeLayout.top}px)`,
+                }}
+              />
+              {activeLyric ? (
+                <div
+                  className="playback-lyric-highlight"
+                  style={{
+                    transform: `translate(${cursorX}px, ${activeLayout.bottom - 28}px)`,
+                  }}
+                >
+                  {activeLyric}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
     </div>
   );
 }
@@ -356,20 +489,27 @@ function drawLyricLane(
   const rowRights = Array.from({ length: LYRIC_MAX_ROWS }, () => Number.NEGATIVE_INFINITY);
   const lyricY = stave.getYForLine(6) + 28;
   measure.slots.forEach((slot, slotIndex) => {
-    const lyric = slot.lyric?.trim().normalize("NFC");
-    if (!lyric) {
-      return;
+    const lyrics = slot.lyrics.length
+      ? slot.lyrics
+      : slot.lyric?.trim()
+        ? [{ lyric: slot.lyric, row: 0 }]
+        : [];
+    for (const slotLyric of lyrics) {
+      const lyric = slotLyric.lyric.trim().normalize("NFC");
+      if (!lyric) {
+        continue;
+      }
+
+      const x = slotToX(stave, slotIndex);
+      const width = lyricVisualWidth(lyric);
+      const left = x - width / 2;
+      const right = left + width;
+      const row = firstAvailableLyricRow(rowRights, left, slotLyric.row);
+      const y = lyricY + row * LYRIC_ROW_GAP_PX;
+
+      context.fillText(lyric, left, y);
+      rowRights[row] = right;
     }
-
-    const x = slotToX(stave, slotIndex);
-    const width = lyricVisualWidth(lyric);
-    const left = x - width / 2;
-    const right = left + width;
-    const row = firstAvailableLyricRow(rowRights, left);
-    const y = lyricY + row * LYRIC_ROW_GAP_PX;
-
-    context.fillText(lyric, left, y);
-    rowRights[row] = right;
   });
   context.restore();
 }
@@ -383,10 +523,15 @@ function lyricVisualWidth(text: string): number {
   }, 0);
 }
 
-function firstAvailableLyricRow(rowRights: number[], left: number): number {
-  const row = rowRights.findIndex((right) => left >= right + LYRIC_MIN_GAP_PX);
-  if (row >= 0) {
-    return row;
+function firstAvailableLyricRow(rowRights: number[], left: number, preferredRow: number): number {
+  const clampedRow = Math.min(LYRIC_MAX_ROWS - 1, Math.max(0, preferredRow));
+  if (left >= rowRights[clampedRow] + LYRIC_MIN_GAP_PX) {
+    return clampedRow;
+  }
+
+  const availableRow = rowRights.findIndex((right) => left >= right + LYRIC_MIN_GAP_PX);
+  if (availableRow >= 0) {
+    return availableRow;
   }
 
   return rowRights.indexOf(Math.min(...rowRights));
@@ -401,6 +546,58 @@ function slotToX(stave: Stave, slot: number): number {
   const startX = stave.getNoteStartX();
   const endX = stave.getNoteEndX();
   return startX + ((slot + 0.5) / SLOTS_PER_MEASURE) * (endX - startX);
+}
+
+function measureLayoutFromStave(stave: Stave, measure: number): MeasureLayout {
+  const slotZero = slotToX(stave, 0);
+  const slotOne = slotToX(stave, 1);
+  const slotWidth = Math.max(1, slotOne - slotZero);
+  const gridStartX = slotZero - slotWidth / 2;
+  const gridEndX = gridStartX + slotWidth * SLOTS_PER_MEASURE;
+  const top = stave.getYForLine(0) - 46;
+  const bottom = stave.getYForLine(6) + 68;
+
+  return {
+    bottom,
+    gridEndX,
+    gridStartX,
+    measure,
+    slotWidth,
+    top,
+  };
+}
+
+function timeToPlaybackPosition(currentTime: number, bpm: number, measureCount: number): PlaybackPosition {
+  const beatSeconds = 60 / Math.max(bpm || 120, 1);
+  const measureSeconds = beatSeconds * 4;
+  const slotSeconds = measureSeconds / SLOTS_PER_MEASURE;
+  const maxMeasureIndex = Math.max(0, measureCount - 1);
+  const measureIndex = Math.min(maxMeasureIndex, Math.max(0, Math.floor(currentTime / measureSeconds)));
+  const measureStart = measureIndex * measureSeconds;
+  const slotProgress = clamp((currentTime - measureStart) / slotSeconds, 0, SLOTS_PER_MEASURE);
+  const slot = Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, Math.floor(slotProgress)));
+
+  return {
+    measure: measureIndex + 1,
+    slot,
+    slotProgress,
+  };
+}
+
+function findMeasureLayoutAtPoint(layouts: MeasureLayout[], x: number, y: number): MeasureLayout | null {
+  return (
+    layouts.find(
+      (layout) =>
+        y >= layout.top - 28 &&
+        y <= layout.bottom + 28 &&
+        x >= layout.gridStartX - 36 &&
+        x <= layout.gridEndX + 36,
+    ) ?? null
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 function drawMeasureNumber(
@@ -438,7 +635,9 @@ function isEngravedDisplayMeasure(measure: Measure): measure is EngravedDisplayM
 }
 
 function hasAnyLyrics(measures: Measure[]): boolean {
-  return measures.some((measure) => measure.slots.some((slot) => Boolean(slot.lyric?.trim())));
+  return measures.some((measure) =>
+    measure.slots.some((slot) => Boolean(slot.lyric?.trim()) || slot.lyrics.some((lyric) => Boolean(lyric.lyric.trim()))),
+  );
 }
 
 function measuresFromEngraved(engravedMeasures: EngravedMeasure[]): EngravedDisplayMeasure[] {
@@ -446,11 +645,11 @@ function measuresFromEngraved(engravedMeasures: EngravedMeasure[]): EngravedDisp
     const slots = emptySlots();
     for (const apiSlot of measure.slots ?? []) {
       const slot = slots[Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, apiSlot.slot))];
-      slot.lyric = mergeLyric(slot.lyric, apiSlot.lyric ?? null);
+      addSlotLyric(slot, apiSlot.lyric ?? null, 0);
     }
     for (const lyricSlot of measure.lyric_slots ?? []) {
       const slot = slots[Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, lyricSlot.slot))];
-      slot.lyric = mergeLyric(slot.lyric, lyricSlot.lyric);
+      addSlotLyric(slot, lyricSlot.lyric, lyricSlot.row ?? 0);
     }
     const displayVoice1 = measure.voice1.map((tick) => engravedTickToDisplayTick(tick, slots));
     const displayVoice2 = measure.voice2.map((tick) => engravedTickToDisplayTick(tick, slots));
@@ -478,7 +677,7 @@ function engravedTickToDisplayTick(
   } else {
     slot.voice2 = dedupeNotationEvents([...slot.voice2, ...events]);
   }
-  slot.lyric = mergeLyric(slot.lyric, tick.lyric ?? events.find((event) => event.lyric)?.lyric ?? null);
+  addSlotLyric(slot, tick.lyric ?? events.find((event) => event.lyric)?.lyric ?? null, 0);
 
   return {
     slot: tick.slot,
@@ -513,7 +712,7 @@ function measuresFromMidiTicks(ticks: MidiTickEvent[]): Measure[] {
         confidence: tick.confidence,
       };
       addNotationEvent(slot, event);
-      slot.lyric = mergeLyric(slot.lyric, tick.lyric ?? null);
+      addSlotLyric(slot, tick.lyric ?? null, 0);
     }
     return { slots };
   });
@@ -541,7 +740,7 @@ function measuresFromScoreEvents(events: ScoreEvent[], bpm: number): Measure[] {
       );
       const slot = slots[slotIndex];
       addNotationEvent(slot, scoreEventToNotationEvent(event));
-      slot.lyric = mergeLyric(slot.lyric, event.lyric ?? null);
+      addSlotLyric(slot, event.lyric ?? null, 0);
     }
     return { slots };
   });
@@ -567,7 +766,7 @@ function applyWordsFallback(measures: Measure[], words: LyricWord[], bpm: number
     );
     const targetSlot = firstAvailableLyricSlot(measure.slots, slotIndex);
     if (targetSlot !== null) {
-      measure.slots[targetSlot].lyric = word.word.trim().normalize("NFC");
+      addSlotLyric(measure.slots[targetSlot], word.word.trim().normalize("NFC"), 0);
     }
   }
 
@@ -576,7 +775,7 @@ function applyWordsFallback(measures: Measure[], words: LyricWord[], bpm: number
 
 function firstAvailableLyricSlot(slots: MeasureSlot[], preferredSlot: number): number | null {
   for (let slot = preferredSlot; slot < SLOTS_PER_MEASURE; slot += 1) {
-    if (!slots[slot].lyric?.trim()) {
+    if (!slots[slot].lyric?.trim() && slots[slot].lyrics.length === 0) {
       return slot;
     }
   }
@@ -611,7 +810,22 @@ function emptySlots(): MeasureSlot[] {
     voice1: [],
     voice2: [],
     lyric: null,
+    lyrics: [],
   }));
+}
+
+function addSlotLyric(slot: MeasureSlot, next: string | null | undefined, row: number) {
+  const cleanNext = next?.trim().normalize("NFC");
+  if (!cleanNext) {
+    return;
+  }
+
+  const cleanRow = Math.min(LYRIC_MAX_ROWS - 1, Math.max(0, row));
+  if (!slot.lyrics.some((lyric) => lyric.lyric === cleanNext && lyric.row === cleanRow)) {
+    slot.lyrics.push({ lyric: cleanNext, row: cleanRow });
+    slot.lyrics.sort((a, b) => a.row - b.row || a.lyric.localeCompare(b.lyric));
+  }
+  slot.lyric = mergeLyric(slot.lyric, cleanNext);
 }
 
 function addNotationEvent(slot: MeasureSlot, event: NotationEvent) {

--- a/apps/web/components/DrumSheet.tsx
+++ b/apps/web/components/DrumSheet.tsx
@@ -633,9 +633,12 @@ function hasAnyLyrics(measures: Measure[]): boolean {
 function measuresFromEngraved(engravedMeasures: EngravedMeasure[]): EngravedDisplayMeasure[] {
   return engravedMeasures.map((measure) => {
     const slots = emptySlots();
-    for (const apiSlot of measure.slots ?? []) {
-      const slot = slots[Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, apiSlot.slot))];
-      addSlotLyric(slot, apiSlot.lyric ?? null, 0);
+    const hasLyricSlots = (measure.lyric_slots?.length ?? 0) > 0;
+    if (!hasLyricSlots) {
+      for (const apiSlot of measure.slots ?? []) {
+        const slot = slots[Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, apiSlot.slot))];
+        addSlotLyric(slot, apiSlot.lyric ?? null, 0);
+      }
     }
     for (const lyricSlot of measure.lyric_slots ?? []) {
       const slot = slots[Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, lyricSlot.slot))];
@@ -811,10 +814,8 @@ function addSlotLyric(slot: MeasureSlot, next: string | null | undefined, row: n
   }
 
   const cleanRow = Math.min(LYRIC_MAX_ROWS - 1, Math.max(0, row));
-  if (!slot.lyrics.some((lyric) => lyric.lyric === cleanNext && lyric.row === cleanRow)) {
-    slot.lyrics.push({ lyric: cleanNext, row: cleanRow });
-    slot.lyrics.sort((a, b) => a.row - b.row || a.lyric.localeCompare(b.lyric));
-  }
+  slot.lyrics.push({ lyric: cleanNext, row: cleanRow });
+  slot.lyrics.sort((a, b) => a.row - b.row);
   slot.lyric = mergeLyric(slot.lyric, cleanNext);
 }
 

--- a/apps/web/components/DrumSheet.tsx
+++ b/apps/web/components/DrumSheet.tsx
@@ -8,6 +8,7 @@ type Props = {
   audioCurrentTime?: number;
   onSeek?: (time: number) => void;
   score: AnalysisResult;
+  showLyrics?: boolean;
 };
 type VoiceNumber = 1 | 2;
 type NotationEvent = Pick<
@@ -59,19 +60,20 @@ const MEASURES_PER_LINE = 4;
 const MEASURE_WIDTH = 320;
 const LEFT_MARGIN = 28;
 const TOP_MARGIN = 26;
-const LINE_HEIGHT = 196;
+const LINE_HEIGHT_WITH_LYRICS = 178;
+const LINE_HEIGHT_WITHOUT_LYRICS = 142;
 const SLOTS_PER_MEASURE = 16;
 const LYRIC_FONT_SIZE = 12;
-const LYRIC_MIN_GAP_PX = 6;
-const LYRIC_ROW_GAP_PX = 18;
+const LYRIC_HORIZONTAL_PADDING_PX = 5;
 const LYRIC_MAX_ROWS = 2;
 
-export function DrumSheet({ audioCurrentTime = 0, onSeek, score }: Props) {
+export function DrumSheet({ audioCurrentTime = 0, onSeek, score, showLyrics = true }: Props) {
   const boardRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const svgLayerRef = useRef<HTMLDivElement | null>(null);
   const [measureLayouts, setMeasureLayouts] = useState<MeasureLayout[]>([]);
   const measures = useMemo(() => toMeasures(score), [score]);
+  const lineHeight = showLyrics ? LINE_HEIGHT_WITH_LYRICS : LINE_HEIGHT_WITHOUT_LYRICS;
   const playbackPosition = useMemo(
     () => timeToPlaybackPosition(audioCurrentTime, score.bpm, measures.length),
     [audioCurrentTime, measures.length, score.bpm],
@@ -79,10 +81,11 @@ export function DrumSheet({ audioCurrentTime = 0, onSeek, score }: Props) {
   const activeLayout = measureLayouts[playbackPosition.measure - 1] ?? null;
   const activeMeasure = measures[playbackPosition.measure - 1] ?? null;
   const activeSlot = activeMeasure?.slots[playbackPosition.slot] ?? null;
-  const activeLyric =
-    activeSlot?.lyrics[0]?.lyric?.trim().normalize("NFC") ??
-    activeSlot?.lyric?.trim().normalize("NFC") ??
-    null;
+  const activeLyric = showLyrics
+    ? (activeSlot?.lyrics[0]?.lyric?.trim().normalize("NFC") ??
+      activeSlot?.lyric?.trim().normalize("NFC") ??
+      null)
+    : null;
   const cursorX = activeLayout
     ? activeLayout.gridStartX +
       (playbackPosition.slotProgress / SLOTS_PER_MEASURE) * (activeLayout.gridEndX - activeLayout.gridStartX)
@@ -99,7 +102,7 @@ export function DrumSheet({ audioCurrentTime = 0, onSeek, score }: Props) {
     container.innerHTML = "";
 
     const width = LEFT_MARGIN * 2 + MEASURES_PER_LINE * MEASURE_WIDTH;
-    const height = Math.max(260, Math.ceil(measures.length / MEASURES_PER_LINE) * LINE_HEIGHT + TOP_MARGIN);
+    const height = Math.max(240, Math.ceil(measures.length / MEASURES_PER_LINE) * lineHeight + TOP_MARGIN);
     const renderer = new Renderer(container, Renderer.Backends.SVG);
     renderer.resize(width, height);
 
@@ -111,7 +114,7 @@ export function DrumSheet({ audioCurrentTime = 0, onSeek, score }: Props) {
       const column = index % MEASURES_PER_LINE;
       const row = Math.floor(index / MEASURES_PER_LINE);
       const x = LEFT_MARGIN + column * MEASURE_WIDTH;
-      const y = TOP_MARGIN + row * LINE_HEIGHT;
+      const y = TOP_MARGIN + row * lineHeight;
       const staveWidth = MEASURE_WIDTH;
 
       const stave = new Stave(x, y, staveWidth);
@@ -146,12 +149,14 @@ export function DrumSheet({ audioCurrentTime = 0, onSeek, score }: Props) {
         drawHiHatStateMarks(context, upperNotes[tickIndex], tick);
         drawGhostSnareMarks(context, upperNotes[tickIndex], tick);
       });
-      drawLyricLane(context, stave, measure);
-      nextLayouts.push(measureLayoutFromStave(stave, index + 1));
+      if (showLyrics) {
+        drawLyricLane(context, stave, measure);
+      }
+      nextLayouts.push(measureLayoutFromStave(stave, index + 1, showLyrics));
     });
 
     setMeasureLayouts(nextLayouts);
-  }, [measures]);
+  }, [lineHeight, measures, showLyrics]);
 
   useEffect(() => {
     const layout = activeLayout;
@@ -486,7 +491,7 @@ function drawLyricLane(
 ) {
   context.save();
   context.setFont("Arial, Malgun Gothic, sans-serif", LYRIC_FONT_SIZE);
-  const rowRights = Array.from({ length: LYRIC_MAX_ROWS }, () => Number.NEGATIVE_INFINITY);
+  let lastRight = Number.NEGATIVE_INFINITY;
   const lyricY = stave.getYForLine(6) + 28;
   measure.slots.forEach((slot, slotIndex) => {
     const lyrics = slot.lyrics.length
@@ -502,13 +507,12 @@ function drawLyricLane(
 
       const x = slotToX(stave, slotIndex);
       const width = lyricVisualWidth(lyric);
-      const left = x - width / 2;
+      const desiredLeft = x - width / 2;
+      const left = Math.max(desiredLeft, lastRight + LYRIC_HORIZONTAL_PADDING_PX);
       const right = left + width;
-      const row = firstAvailableLyricRow(rowRights, left, slotLyric.row);
-      const y = lyricY + row * LYRIC_ROW_GAP_PX;
 
-      context.fillText(lyric, left, y);
-      rowRights[row] = right;
+      context.fillText(lyric, left, lyricY);
+      lastRight = right;
     }
   });
   context.restore();
@@ -523,20 +527,6 @@ function lyricVisualWidth(text: string): number {
   }, 0);
 }
 
-function firstAvailableLyricRow(rowRights: number[], left: number, preferredRow: number): number {
-  const clampedRow = Math.min(LYRIC_MAX_ROWS - 1, Math.max(0, preferredRow));
-  if (left >= rowRights[clampedRow] + LYRIC_MIN_GAP_PX) {
-    return clampedRow;
-  }
-
-  const availableRow = rowRights.findIndex((right) => left >= right + LYRIC_MIN_GAP_PX);
-  if (availableRow >= 0) {
-    return availableRow;
-  }
-
-  return rowRights.indexOf(Math.min(...rowRights));
-}
-
 function isHangulSyllable(char: string): boolean {
   const code = char.charCodeAt(0);
   return code >= 0xac00 && code <= 0xd7a3;
@@ -548,14 +538,14 @@ function slotToX(stave: Stave, slot: number): number {
   return startX + ((slot + 0.5) / SLOTS_PER_MEASURE) * (endX - startX);
 }
 
-function measureLayoutFromStave(stave: Stave, measure: number): MeasureLayout {
+function measureLayoutFromStave(stave: Stave, measure: number, showLyrics: boolean): MeasureLayout {
   const slotZero = slotToX(stave, 0);
   const slotOne = slotToX(stave, 1);
   const slotWidth = Math.max(1, slotOne - slotZero);
   const gridStartX = slotZero - slotWidth / 2;
   const gridEndX = gridStartX + slotWidth * SLOTS_PER_MEASURE;
   const top = stave.getYForLine(0) - 46;
-  const bottom = stave.getYForLine(6) + 68;
+  const bottom = showLyrics ? stave.getYForLine(6) + 52 : stave.getYForLine(5) + 24;
 
   return {
     bottom,

--- a/apps/web/components/SynchronizedScorePlayer.tsx
+++ b/apps/web/components/SynchronizedScorePlayer.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import type { AnalysisResult } from "@/lib/types";
+
+export type PlaybackSource =
+  | {
+      kind: "audio";
+      title: string;
+      url: string;
+    }
+  | {
+      kind: "youtube";
+      title: string;
+      url: string;
+      videoId: string;
+    };
+
+export type SynchronizedScorePlayerHandle = {
+  pause: () => void;
+  play: () => void;
+  seekTo: (seconds: number) => void;
+};
+
+type Props = {
+  currentTime: number;
+  onTimeChange: (time: number) => void;
+  score: AnalysisResult;
+  source: PlaybackSource;
+};
+
+type YouTubeEvent = { data: number; target: YouTubePlayer };
+type YouTubePlayer = {
+  destroy: () => void;
+  getCurrentTime: () => number;
+  getDuration: () => number;
+  pauseVideo: () => void;
+  playVideo: () => void;
+  seekTo: (seconds: number, allowSeekAhead: boolean) => void;
+  setVolume: (volume: number) => void;
+};
+type YouTubeApi = {
+  Player: new (
+    element: HTMLElement,
+    options: {
+      events: {
+        onReady: (event: { target: YouTubePlayer }) => void;
+        onStateChange: (event: YouTubeEvent) => void;
+      };
+      height: string;
+      playerVars: Record<string, number | string>;
+      videoId: string;
+      width: string;
+    },
+  ) => YouTubePlayer;
+};
+
+declare global {
+  interface Window {
+    YT?: YouTubeApi;
+    onYouTubeIframeAPIReady?: () => void;
+  }
+}
+
+const YOUTUBE_PLAYING = 1;
+const YOUTUBE_PAUSED = 2;
+const YOUTUBE_ENDED = 0;
+
+let youtubeApiPromise: Promise<YouTubeApi> | null = null;
+
+export const SynchronizedScorePlayer = forwardRef<SynchronizedScorePlayerHandle, Props>(
+  function SynchronizedScorePlayer({ currentTime, onTimeChange, score, source }, ref) {
+    const audioRef = useRef<HTMLAudioElement | null>(null);
+    const volumeRef = useRef(0.85);
+    const youtubeMountRef = useRef<HTMLDivElement | null>(null);
+    const youtubePlayerRef = useRef<YouTubePlayer | null>(null);
+    const [duration, setDuration] = useState(0);
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [volume, setVolume] = useState(0.85);
+    const sourceKey = source.kind === "youtube" ? `youtube:${source.videoId}` : `audio:${source.url}`;
+    const scoreDuration = useMemo(() => estimateScoreDuration(score), [score]);
+    const playbackDuration = duration > 0 ? duration : scoreDuration;
+
+    useEffect(() => {
+      volumeRef.current = volume;
+    }, [volume]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        pause: () => pauseSource(source, audioRef.current, youtubePlayerRef.current),
+        play: () => {
+          void playSource(source, audioRef.current, youtubePlayerRef.current);
+        },
+        seekTo: (seconds: number) => {
+          seekSource(source, audioRef.current, youtubePlayerRef.current, seconds);
+          onTimeChange(clampTime(seconds, playbackDuration));
+        },
+      }),
+      [onTimeChange, playbackDuration, source],
+    );
+
+    useEffect(() => {
+      setIsPlaying(false);
+      setDuration(0);
+      onTimeChange(0);
+    }, [onTimeChange, sourceKey]);
+
+    useEffect(() => {
+      if (source.kind !== "audio") {
+        return;
+      }
+
+      const audio = audioRef.current;
+      if (!audio) {
+        return;
+      }
+
+      audio.volume = volume;
+    }, [source.kind, volume]);
+
+    useEffect(() => {
+      if (source.kind !== "youtube") {
+        return;
+      }
+
+      youtubePlayerRef.current?.setVolume(Math.round(volume * 100));
+    }, [source.kind, volume]);
+
+    useEffect(() => {
+      if (source.kind !== "youtube") {
+        youtubePlayerRef.current?.destroy();
+        youtubePlayerRef.current = null;
+        return;
+      }
+
+      let disposed = false;
+      const mount = youtubeMountRef.current;
+      if (!mount) {
+        return;
+      }
+
+      mount.innerHTML = "";
+      void loadYouTubeApi().then((api) => {
+        if (disposed || !youtubeMountRef.current) {
+          return;
+        }
+
+        const player = new api.Player(youtubeMountRef.current, {
+          height: "180",
+          width: "320",
+          videoId: source.videoId,
+          playerVars: {
+            controls: 0,
+            disablekb: 1,
+            modestbranding: 1,
+            playsinline: 1,
+            rel: 0,
+          },
+          events: {
+            onReady: (event) => {
+              event.target.setVolume(Math.round(volumeRef.current * 100));
+              const nextDuration = event.target.getDuration();
+              if (Number.isFinite(nextDuration) && nextDuration > 0) {
+                setDuration(nextDuration);
+              }
+            },
+            onStateChange: (event) => {
+              if (event.data === YOUTUBE_PLAYING) {
+                setIsPlaying(true);
+                return;
+              }
+              if (event.data === YOUTUBE_PAUSED || event.data === YOUTUBE_ENDED) {
+                setIsPlaying(false);
+              }
+            },
+          },
+        });
+        youtubePlayerRef.current = player;
+      });
+
+      return () => {
+        disposed = true;
+        youtubePlayerRef.current?.destroy();
+        youtubePlayerRef.current = null;
+      };
+    }, [source]);
+
+    useEffect(() => {
+      let frame = 0;
+      const tick = () => {
+        const nextTime = readCurrentTime(source, audioRef.current, youtubePlayerRef.current);
+        if (Number.isFinite(nextTime)) {
+          onTimeChange(nextTime);
+        }
+
+        const nextDuration = readDuration(source, audioRef.current, youtubePlayerRef.current);
+        if (Number.isFinite(nextDuration) && nextDuration > 0) {
+          setDuration((current) => (Math.abs(current - nextDuration) > 0.25 ? nextDuration : current));
+        }
+
+        frame = requestAnimationFrame(tick);
+      };
+
+      frame = requestAnimationFrame(tick);
+      return () => cancelAnimationFrame(frame);
+    }, [onTimeChange, source]);
+
+    function togglePlayback() {
+      if (isPlaying) {
+        pauseSource(source, audioRef.current, youtubePlayerRef.current);
+        return;
+      }
+
+      void playSource(source, audioRef.current, youtubePlayerRef.current);
+    }
+
+    function seekTo(seconds: number) {
+      const safeTime = clampTime(seconds, playbackDuration);
+      seekSource(source, audioRef.current, youtubePlayerRef.current, safeTime);
+      onTimeChange(safeTime);
+    }
+
+    return (
+      <section className="player-panel" aria-label="Synchronized audio player">
+        <div className="player-header">
+          <div>
+            <div className="player-kicker">{source.kind === "youtube" ? "YouTube source" : "Uploaded audio"}</div>
+            <div className="player-title">{source.title}</div>
+          </div>
+          <button className="player-button" onClick={togglePlayback} type="button">
+            {isPlaying ? "Pause" : "Play"}
+          </button>
+        </div>
+
+        {source.kind === "audio" ? (
+          <audio
+            ref={audioRef}
+            onDurationChange={(event) => setDuration(safeDuration(event.currentTarget.duration))}
+            onEnded={() => setIsPlaying(false)}
+            onLoadedMetadata={(event) => setDuration(safeDuration(event.currentTarget.duration))}
+            onPause={() => setIsPlaying(false)}
+            onPlay={() => setIsPlaying(true)}
+            preload="metadata"
+            src={source.url}
+          />
+        ) : (
+          <div className="youtube-player-shell" aria-label="YouTube audio source">
+            <div ref={youtubeMountRef} />
+          </div>
+        )}
+
+        <div className="transport-row">
+          <span className="time-label">{formatTime(currentTime)}</span>
+          <input
+            aria-label="Seek playback"
+            className="seek-slider"
+            max={Math.max(playbackDuration, 0.01)}
+            min={0}
+            onChange={(event) => seekTo(Number(event.target.value))}
+            step={0.01}
+            type="range"
+            value={Math.min(currentTime, Math.max(playbackDuration, 0.01))}
+          />
+          <span className="time-label">{formatTime(playbackDuration)}</span>
+        </div>
+
+        <label className="volume-row">
+          <span>Volume</span>
+          <input
+            aria-label="Volume"
+            max={1}
+            min={0}
+            onChange={(event) => setVolume(Number(event.target.value))}
+            step={0.01}
+            type="range"
+            value={volume}
+          />
+        </label>
+      </section>
+    );
+  },
+);
+
+function loadYouTubeApi(): Promise<YouTubeApi> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("YouTube player is only available in the browser."));
+  }
+
+  if (window.YT?.Player) {
+    return Promise.resolve(window.YT);
+  }
+
+  if (youtubeApiPromise) {
+    return youtubeApiPromise;
+  }
+
+  youtubeApiPromise = new Promise((resolve) => {
+    const previousReadyHandler = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = () => {
+      previousReadyHandler?.();
+      if (window.YT?.Player) {
+        resolve(window.YT);
+      }
+    };
+
+    const existingScript = document.querySelector<HTMLScriptElement>('script[src="https://www.youtube.com/iframe_api"]');
+    if (existingScript) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://www.youtube.com/iframe_api";
+    script.async = true;
+    document.head.appendChild(script);
+  });
+
+  return youtubeApiPromise;
+}
+
+function playSource(source: PlaybackSource, audio: HTMLAudioElement | null, youtubePlayer: YouTubePlayer | null) {
+  if (source.kind === "audio") {
+    return audio?.play();
+  }
+
+  youtubePlayer?.playVideo();
+  return undefined;
+}
+
+function pauseSource(source: PlaybackSource, audio: HTMLAudioElement | null, youtubePlayer: YouTubePlayer | null) {
+  if (source.kind === "audio") {
+    audio?.pause();
+    return;
+  }
+
+  youtubePlayer?.pauseVideo();
+}
+
+function seekSource(
+  source: PlaybackSource,
+  audio: HTMLAudioElement | null,
+  youtubePlayer: YouTubePlayer | null,
+  seconds: number,
+) {
+  if (source.kind === "audio") {
+    if (audio) {
+      audio.currentTime = seconds;
+    }
+    return;
+  }
+
+  youtubePlayer?.seekTo(seconds, true);
+}
+
+function readCurrentTime(
+  source: PlaybackSource,
+  audio: HTMLAudioElement | null,
+  youtubePlayer: YouTubePlayer | null,
+): number {
+  if (source.kind === "audio") {
+    return audio?.currentTime ?? 0;
+  }
+
+  return youtubePlayer?.getCurrentTime() ?? 0;
+}
+
+function readDuration(
+  source: PlaybackSource,
+  audio: HTMLAudioElement | null,
+  youtubePlayer: YouTubePlayer | null,
+): number {
+  if (source.kind === "audio") {
+    return safeDuration(audio?.duration ?? 0);
+  }
+
+  return safeDuration(youtubePlayer?.getDuration() ?? 0);
+}
+
+function safeDuration(duration: number): number {
+  return Number.isFinite(duration) && duration > 0 ? duration : 0;
+}
+
+function clampTime(seconds: number, duration: number): number {
+  return Math.min(Math.max(0, seconds), Math.max(duration, 0));
+}
+
+function estimateScoreDuration(score: AnalysisResult): number {
+  const beatSeconds = 60 / Math.max(score.bpm || 120, 1);
+  const measureSeconds = beatSeconds * 4;
+  const measureDuration = Math.max(1, score.engraved_measures.length) * measureSeconds;
+  const lastWord = Math.max(...score.words.map((word) => word.end), 0);
+  const lastEvent = Math.max(...score.events.map((event) => event.time), 0);
+  return Math.max(measureDuration, lastWord, lastEvent);
+}
+
+function formatTime(seconds: number): string {
+  const safeSeconds = Math.max(0, Number.isFinite(seconds) ? seconds : 0);
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainingSeconds = Math.floor(safeSeconds % 60);
+  return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`;
+}

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -58,6 +58,7 @@ export type EngravedTick = {
 export type LyricSlot = {
   slot: number;
   lyric: string;
+  row?: number;
 };
 
 export type EngravedSlot = {


### PR DESCRIPTION
## 변경 내용 요약
- 분석된 악보를 원본 오디오 또는 YouTube 플레이어 시간과 동기화해 재생할 수 있게 했습니다.
- 현재 재생 슬롯, 커서, 활성 가사를 DrumSheet 위에 표시하고 악보 클릭으로 seek할 수 있게 했습니다.
- YouTube 캡션 텍스트를 Whisper 단어 타이밍과 보컬 에너지에 맞춰 정렬하는 백엔드 정렬 단계를 추가했습니다.
- YouTube 캡션 포맷 fallback을 넓히고 악보 가사 표시를 켜고 끌 수 있게 했습니다.
- `lyric_slots`가 있는 응답에서 기존 slot lyric을 중복 병합하지 않고, 반복 가사는 필요한 만큼 보존합니다.

## 변경 이유
- 생성된 악보와 실제 오디오가 같은 시간축에서 맞는지 사용자가 바로 검수할 수 있어야 합니다.
- YouTube 캡션은 텍스트 품질은 좋지만 cue 타이밍이 거칠 수 있어, Whisper 타이밍을 이용한 보정이 필요합니다.
- 캡션 포맷이 영상마다 달라 하나의 caption 형식만 가정하면 가사를 가져오지 못할 수 있습니다.
- 연주 확인 중에는 가사 Lane을 숨기고 드럼 표기만 더 촘촘히 볼 수 있어야 합니다.
- 독립 Lyric Lane 데이터가 있을 때 같은 가사를 slot fallback과 중복 렌더링하면 악보가 읽기 어려워집니다.

## 주요 변경 사항
- `LyricSlot.row`를 추가하고 백엔드 Lyric Lane 배치가 두 행을 사용할 수 있게 했습니다.
- `lyric_alignment.py`에서 YouTube 캡션 단위를 Whisper timing unit에 정렬하고, 다음 timing anchor가 부족하면 균등 분배 fallback을 사용합니다.
- YouTube 캡션이 있는 경우에도 보컬 stem과 Whisper timing을 생성해 캡션 텍스트에 더 정확한 시작/종료 시간을 부여합니다.
- YouTube caption 후보를 언어/포맷 우선순위로 순회하고 `json3`, `vtt`, `srv*`, `ttml/xml` 파싱을 지원합니다.
- `SynchronizedScorePlayer`를 추가해 업로드 오디오와 YouTube IFrame Player를 공통 transport UI로 제어합니다.
- `DrumSheet`는 재생 시간 기반 슬롯 하이라이트, 빨간 커서, 활성 가사 배지를 표시하고 클릭/키보드 seek를 지원합니다.
- `showLyrics` 옵션과 화면 토글로 가사 Lane을 숨긴 상태의 더 낮은 악보 레이아웃을 지원합니다.
- `engraved_measures.lyric_slots`가 있으면 `measure.slots[*].lyric` fallback을 건너뛰어 중복 가사 렌더링을 방지합니다.
- 이전 흐름: 분석 결과 악보만 정적으로 렌더링했습니다.
- 변경 후 흐름: 분석 후 원본 소스를 재생하면서 악보 위치와 가사를 동기화해 확인할 수 있습니다.

## 테스트 방법
- `git diff --check`
- `git diff --cached --check`
- `npm --workspace apps/web run lint`
- `npm --workspace apps/web run build`
- `py -3 harness\beatly_quality_harness.py`는 실행하지 못했습니다. 이 환경에는 `py`, `python`, `python3` 명령이 없고 `harness\beatly_quality_harness.py` 파일도 없습니다.
