### PR TITLE
[FE] 악보 PDF 내보내기 지원

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { DrumSheet } from "@/components/DrumSheet";
+import { DrumSheet, type DrumSheetHandle, type PrintableScoreSystem } from "@/components/DrumSheet";
 import {
   SynchronizedScorePlayer,
   type PlaybackSource,
@@ -15,6 +15,7 @@ type SourceType = "upload" | "youtube";
 export default function Home() {
   const audioObjectUrlRef = useRef<string | null>(null);
   const playerRef = useRef<SynchronizedScorePlayerHandle | null>(null);
+  const sheetRef = useRef<DrumSheetHandle | null>(null);
   const [sourceType, setSourceType] = useState<SourceType>("upload");
   const [file, setFile] = useState<File | null>(null);
   const [youtubeUrl, setYoutubeUrl] = useState("");
@@ -22,6 +23,7 @@ export default function Home() {
   const [playbackSource, setPlaybackSource] = useState<PlaybackSource | null>(null);
   const [audioCurrentTime, setAudioCurrentTime] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const [enableLyrics, setEnableLyrics] = useState(true);
   const [showLyrics, setShowLyrics] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -121,6 +123,64 @@ export default function Home() {
     setAudioCurrentTime(time);
   }, []);
 
+  const handleExportPdf = useCallback(async () => {
+    if (!score) {
+      return;
+    }
+
+    playerRef.current?.pause();
+    const systems = sheetRef.current?.getPrintableSystems() ?? [];
+    if (!systems.length) {
+      setError("Score preview is not ready for PDF export yet.");
+      return;
+    }
+
+    setError(null);
+    setIsExporting(true);
+    try {
+      const { jsPDF } = await import("jspdf");
+      const pdf = new jsPDF({
+        compress: true,
+        format: "a4",
+        orientation: "landscape",
+        unit: "mm",
+      });
+      const pageWidth = pdf.internal.pageSize.getWidth();
+      const pageHeight = pdf.internal.pageSize.getHeight();
+      const margin = 10;
+      const contentWidth = pageWidth - margin * 2;
+      const gap = 6;
+      let cursorY = margin;
+
+      for (let index = 0; index < systems.length; index += 1) {
+        const system = systems[index];
+        const raster = await rasterizeScoreSystem(system, 3);
+        const labelHeight = 4;
+        const imageHeight = contentWidth * (system.height / system.width);
+        const requiredHeight = labelHeight + imageHeight + (index === systems.length - 1 ? 0 : gap);
+
+        if (cursorY + requiredHeight > pageHeight - margin) {
+          pdf.addPage("a4", "landscape");
+          cursorY = margin;
+        }
+
+        pdf.setFontSize(9);
+        pdf.setTextColor(93, 102, 117);
+        pdf.text(`Measures ${system.measureStart}-${system.measureEnd}`, margin, cursorY + 3);
+        cursorY += labelHeight;
+
+        pdf.addImage(raster, "PNG", margin, cursorY, contentWidth, imageHeight, undefined, "FAST");
+        cursorY += imageHeight + gap;
+      }
+
+      pdf.save(buildPdfFilename(playbackSource?.title ?? (sourceType === "youtube" ? youtubeUrl.trim() : file?.name ?? "")));
+    } catch {
+      setError("Failed to generate the PDF file.");
+    } finally {
+      setIsExporting(false);
+    }
+  }, [file?.name, playbackSource?.title, score, sourceType, youtubeUrl]);
+
   return (
     <main className="page">
       <div className="shell">
@@ -174,6 +234,14 @@ export default function Home() {
               {isLoading ? "Analyzing..." : "Generate Score"}
             </button>
             <button
+              className="button"
+              disabled={!score || isLoading || isExporting}
+              onClick={handleExportPdf}
+              type="button"
+            >
+              {isExporting ? "Downloading PDF..." : "Export PDF"}
+            </button>
+            <button
               className={showLyrics ? "source-button active" : "source-button"}
               onClick={() => setShowLyrics((current) => !current)}
               type="button"
@@ -216,6 +284,7 @@ export default function Home() {
             <DrumSheet
               audioCurrentTime={audioCurrentTime}
               onSeek={handleScoreSeek}
+              ref={sheetRef}
               score={score}
               showLyrics={showLyrics}
             />
@@ -266,4 +335,53 @@ function formatJobStatus(status: string, detail?: string | null): string {
     return detail ?? "Analysis failed.";
   }
   return detail ?? "Working.";
+}
+
+async function rasterizeScoreSystem(system: PrintableScoreSystem, scale: number): Promise<string> {
+  const svgMarkup = ensureSvgNamespace(system.svgMarkup);
+  const svgBlob = new Blob([svgMarkup], { type: "image/svg+xml;charset=utf-8" });
+  const objectUrl = URL.createObjectURL(svgBlob);
+  try {
+    const image = await loadImage(objectUrl);
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(system.width * scale));
+    canvas.height = Math.max(1, Math.round(system.height * scale));
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Canvas 2D context is unavailable.");
+    }
+
+    context.scale(scale, scale);
+    context.fillStyle = "#ffffff";
+    context.fillRect(0, 0, system.width, system.height);
+    context.drawImage(image, 0, 0, system.width, system.height);
+
+    return canvas.toDataURL("image/png");
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function ensureSvgNamespace(svgMarkup: string): string {
+  if (svgMarkup.includes('xmlns="http://www.w3.org/2000/svg"')) {
+    return svgMarkup;
+  }
+  return svgMarkup.replace("<svg", '<svg xmlns="http://www.w3.org/2000/svg"');
+}
+
+function loadImage(source: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.decoding = "sync";
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("Failed to load the score image."));
+    image.src = source;
+  });
+}
+
+function buildPdfFilename(sourceTitle: string): string {
+  const trimmed = sourceTitle.trim();
+  const withoutExtension = trimmed.replace(/\.[A-Za-z0-9]{1,8}$/, "");
+  const cleaned = withoutExtension.replace(/[<>:"/\\|?*\u0000-\u001f]/g, " ").trim().replace(/\s+/g, "_");
+  return `${(cleaned || "beatly-drum-sheet").slice(0, 96)}.pdf`;
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -142,7 +142,7 @@ export default function Home() {
       const pdf = new jsPDF({
         compress: true,
         format: "a4",
-        orientation: "landscape",
+        orientation: "portrait",
         unit: "mm",
       });
       const pageWidth = pdf.internal.pageSize.getWidth();
@@ -160,7 +160,7 @@ export default function Home() {
         const requiredHeight = labelHeight + imageHeight + (index === systems.length - 1 ? 0 : gap);
 
         if (cursorY + requiredHeight > pageHeight - margin) {
-          pdf.addPage("a4", "landscape");
+          pdf.addPage("a4", "portrait");
           cursorY = margin;
         }
 

--- a/apps/web/components/DrumSheet.tsx
+++ b/apps/web/components/DrumSheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { Articulation, Formatter, Renderer, Stave, StaveNote, Voice } from "vexflow";
 import type { AnalysisResult, DrumNote, EngravedMeasure, LyricWord, MidiTickEvent, ScoreEvent } from "@/lib/types";
 
@@ -45,6 +45,16 @@ type PlaybackPosition = {
   slot: number;
   slotProgress: number;
 };
+export type PrintableScoreSystem = {
+  height: number;
+  measureEnd: number;
+  measureStart: number;
+  svgMarkup: string;
+  width: number;
+};
+export type DrumSheetHandle = {
+  getPrintableSystems: () => PrintableScoreSystem[];
+};
 
 const NOTE_MAP: Record<DrumNote, { key: string; voice: VoiceNumber; notehead: "normal" | "x"; order: number }> = {
   crash: { key: "a/5", voice: 1, notehead: "x", order: 0 },
@@ -67,7 +77,10 @@ const LYRIC_FONT_SIZE = 12;
 const LYRIC_HORIZONTAL_PADDING_PX = 5;
 const LYRIC_MAX_ROWS = 2;
 
-export function DrumSheet({ audioCurrentTime = 0, onSeek, score, showLyrics = true }: Props) {
+export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
+  { audioCurrentTime = 0, onSeek, score, showLyrics = true }: Props,
+  ref,
+) {
   const boardRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const svgLayerRef = useRef<HTMLDivElement | null>(null);
@@ -92,6 +105,14 @@ export function DrumSheet({ audioCurrentTime = 0, onSeek, score, showLyrics = tr
     : 0;
   const activeSlotLeft = activeLayout ? activeLayout.gridStartX + playbackPosition.slot * activeLayout.slotWidth : 0;
   const activeSlotHeight = activeLayout ? activeLayout.bottom - activeLayout.top : 0;
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getPrintableSystems: () => collectPrintableSystems(svgLayerRef.current, measureLayouts),
+    }),
+    [measureLayouts],
+  );
 
   useEffect(() => {
     const container = svgLayerRef.current;
@@ -250,6 +271,85 @@ export function DrumSheet({ audioCurrentTime = 0, onSeek, score, showLyrics = tr
       </div>
     </div>
   );
+});
+
+function collectPrintableSystems(
+  container: HTMLDivElement | null,
+  layouts: MeasureLayout[],
+): PrintableScoreSystem[] {
+  const sourceSvg = container?.querySelector("svg");
+  if (!sourceSvg || !layouts.length) {
+    return [];
+  }
+
+  const parsedViewBox = parseSvgViewBox(sourceSvg.getAttribute("viewBox"));
+  const fullWidth = parsedViewBox?.width ?? svgDimension(sourceSvg, "width");
+  const fullHeight = parsedViewBox?.height ?? svgDimension(sourceSvg, "height");
+  const viewBoxX = parsedViewBox?.x ?? 0;
+  const viewBoxY = parsedViewBox?.y ?? 0;
+  if (fullWidth <= 0 || fullHeight <= 0) {
+    return [];
+  }
+
+  return groupLayoutsBySystem(layouts).map((group) => {
+    const top = Math.max(viewBoxY, Math.floor(Math.min(...group.map((layout) => layout.top)) - 8));
+    const bottom = Math.min(viewBoxY + fullHeight, Math.ceil(Math.max(...group.map((layout) => layout.bottom)) + 8));
+    const height = Math.max(1, bottom - top);
+    const clonedSvg = sourceSvg.cloneNode(true) as SVGSVGElement;
+    clonedSvg.setAttribute("width", String(fullWidth));
+    clonedSvg.setAttribute("height", String(height));
+    clonedSvg.setAttribute("viewBox", `${viewBoxX} ${top} ${fullWidth} ${height}`);
+
+    return {
+      height,
+      measureEnd: group[group.length - 1].measure,
+      measureStart: group[0].measure,
+      svgMarkup: clonedSvg.outerHTML,
+      width: fullWidth,
+    };
+  });
+}
+
+function groupLayoutsBySystem(layouts: MeasureLayout[]): MeasureLayout[][] {
+  const groups: MeasureLayout[][] = [];
+  layouts.forEach((layout) => {
+    const index = Math.max(0, Math.floor((layout.measure - 1) / MEASURES_PER_LINE));
+    if (!groups[index]) {
+      groups[index] = [];
+    }
+    groups[index].push(layout);
+  });
+  return groups.filter((group): group is MeasureLayout[] => Boolean(group?.length));
+}
+
+function svgDimension(svg: SVGSVGElement, attribute: "width" | "height"): number {
+  const raw = Number.parseFloat(svg.getAttribute(attribute) ?? "");
+  if (Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+
+  const parsedViewBox = parseSvgViewBox(svg.getAttribute("viewBox"));
+  if (parsedViewBox) {
+    return attribute === "width" ? parsedViewBox.width : parsedViewBox.height;
+  }
+
+  return 0;
+}
+
+function parseSvgViewBox(value: string | null): { height: number; width: number; x: number; y: number } | null {
+  if (!value) {
+    return null;
+  }
+
+  const [x, y, width, height] = value
+    .trim()
+    .split(/[\s,]+/)
+    .map((part) => Number.parseFloat(part));
+  if (![x, y, width, height].every((part) => Number.isFinite(part))) {
+    return null;
+  }
+
+  return { x, y, width, height };
 }
 
 function simplifyVoice(measure: Measure, voice: VoiceNumber): DisplayTick[] {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "jspdf": "^4.2.1",
     "next": "^15.5.15",
     "react": "^19.0.1",
     "react-dom": "^19.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "name": "@beatly/web",
       "version": "0.1.0",
       "dependencies": {
+        "jspdf": "^4.2.1",
         "next": "^15.5.15",
         "react": "^19.0.1",
         "react-dom": "^19.0.1",
@@ -25,6 +26,15 @@
         "eslint": "^9.17.0",
         "eslint-config-next": "^15.5.15",
         "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@beatly/web": {
@@ -996,6 +1006,19 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1015,6 +1038,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -1860,6 +1890,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -1964,6 +2004,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2014,6 +2074,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2027,6 +2099,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2179,6 +2261,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2851,6 +2943,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -2860,6 +2963,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3212,6 +3321,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3263,6 +3386,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -3752,6 +3881,23 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -4225,6 +4371,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4264,6 +4416,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4375,6 +4534,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.0.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.1.tgz",
@@ -4425,6 +4594,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -4500,6 +4676,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/run-parallel": {
@@ -4809,6 +4995,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -5006,6 +5202,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -5275,6 +5491,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vexflow": {


### PR DESCRIPTION
## 변경 내용 요약
- 생성된 드럼 악보를 PDF 파일로 내보낼 수 있게 했습니다.
- DrumSheet가 인쇄용 시스템 단위 SVG를 추출하고, 페이지는 이를 rasterize해 `jsPDF`로 저장합니다.
- 분석 화면에 PDF 다운로드 버튼을 추가했습니다.
- PDF 페이지 방향을 가로가 아니라 세로로 맞췄습니다.

## 변경 이유
- 사용자가 브라우저 미리보기와 동일한 악보를 바로 인쇄하거나 공유할 수 있어야 합니다.
- 시스템 단위로 잘린 SVG를 페이지에 맞게 배치해야 읽기 쉬운 악보 PDF를 만들 수 있습니다.
- 실제 인쇄 흐름에서는 A4 세로 방향이 더 일반적이라 기본 PDF 방향을 세로로 두는 편이 자연스럽습니다.

## 주요 변경 사항
- `DrumSheet`를 `forwardRef`로 감싸고 인쇄용 시스템 목록을 반환하는 핸들을 추가했습니다.
- SVG `viewBox`를 시스템 단위로 잘라 PNG로 rasterize한 뒤 `jsPDF`에 배치합니다.
- PDF 파일명은 업로드 파일명 또는 YouTube 제목을 기반으로 안전한 파일명으로 정리합니다.
- PDF 생성 시 `jsPDF` 페이지 방향과 추가 페이지 방향을 모두 `portrait`로 사용합니다.
- 화면 흐름은 기존 분석/재생과 같고, 결과가 준비된 뒤 `Export PDF` 버튼으로 다운로드를 시작합니다.
- `apps/web/package.json`과 `package-lock.json`에 `jspdf` 의존성을 추가했습니다.

## 테스트 방법
- `git diff --check`
- `git diff --cached --check`
- `npm --workspace apps/web run lint`
- `npm --workspace apps/web run build`
- `py -3 harness\beatly_quality_harness.py`는 실행하지 못했습니다. 이 환경에는 `py`, `python`, `python3` 명령이 없고 `harness\beatly_quality_harness.py` 파일도 없습니다.
