### PR TITLE
[FE] 재생 추적 토글과 자동 스크롤 개선

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -184,6 +184,12 @@ input {
   gap: 16px;
 }
 
+.player-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .player-kicker {
   margin-bottom: 4px;
   color: var(--muted);
@@ -207,6 +213,18 @@ input {
   color: #fff;
   background: var(--accent);
   cursor: pointer;
+}
+
+.player-follow-button {
+  border: 1px solid var(--line);
+  color: var(--muted);
+  background: #fff;
+}
+
+.player-follow-button.active {
+  border-color: var(--accent);
+  color: #fff;
+  background: var(--accent);
 }
 
 .transport-row,
@@ -281,6 +299,7 @@ input {
   position: absolute;
   inset: 0;
   z-index: 2;
+  opacity: 0;
   pointer-events: none;
 }
 
@@ -290,6 +309,7 @@ input {
   position: absolute;
   top: 0;
   left: 0;
+  will-change: transform;
   pointer-events: none;
 }
 
@@ -351,6 +371,7 @@ input {
     flex-direction: column;
   }
 
+  .player-actions,
   .player-button,
   .seek-slider,
   .volume-row input {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -24,7 +24,9 @@ export default function Home() {
   const [audioCurrentTime, setAudioCurrentTime] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [isPlaybackActive, setIsPlaybackActive] = useState(false);
   const [enableLyrics, setEnableLyrics] = useState(true);
+  const [followPlayback, setFollowPlayback] = useState(true);
   const [showLyrics, setShowLyrics] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusText, setStatusText] = useState<string | null>(null);
@@ -69,6 +71,8 @@ export default function Home() {
       setPlaybackSourceForInput(submittedSourceType, submittedFile, submittedYoutubeUrl);
       setScore(result);
       setAudioCurrentTime(0);
+      setIsPlaybackActive(false);
+      setFollowPlayback(true);
       setStatusText(null);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Analysis failed.");
@@ -276,6 +280,9 @@ export default function Home() {
               <SynchronizedScorePlayer
                 ref={playerRef}
                 currentTime={audioCurrentTime}
+                followPlayback={followPlayback}
+                onFollowPlaybackChange={setFollowPlayback}
+                onPlaybackStateChange={setIsPlaybackActive}
                 onTimeChange={handlePlayerTimeChange}
                 score={score}
                 source={playbackSource}
@@ -283,7 +290,10 @@ export default function Home() {
             ) : null}
             <DrumSheet
               audioCurrentTime={audioCurrentTime}
+              followPlayback={followPlayback}
+              isPlaying={isPlaybackActive}
               onSeek={handleScoreSeek}
+              onFollowPlaybackChange={setFollowPlayback}
               ref={sheetRef}
               score={score}
               showLyrics={showLyrics}

--- a/apps/web/components/DrumSheet.tsx
+++ b/apps/web/components/DrumSheet.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { Articulation, Formatter, Renderer, Stave, StaveNote, Voice } from "vexflow";
 import type { AnalysisResult, DrumNote, EngravedMeasure, LyricWord, MidiTickEvent, ScoreEvent } from "@/lib/types";
 
 type Props = {
   audioCurrentTime?: number;
+  followPlayback?: boolean;
+  isPlaying?: boolean;
+  onFollowPlaybackChange?: (enabled: boolean) => void;
   onSeek?: (time: number) => void;
   score: AnalysisResult;
   showLyrics?: boolean;
@@ -76,14 +79,22 @@ const SLOTS_PER_MEASURE = 16;
 const LYRIC_FONT_SIZE = 12;
 const LYRIC_HORIZONTAL_PADDING_PX = 5;
 const LYRIC_MAX_ROWS = 2;
+const AUTO_SCROLL_GUARD_MS = 1000;
 
 export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
-  { audioCurrentTime = 0, onSeek, score, showLyrics = true }: Props,
+  { audioCurrentTime = 0, followPlayback = true, isPlaying = false, onFollowPlaybackChange, onSeek, score, showLyrics = true }: Props,
   ref,
 ) {
   const boardRef = useRef<HTMLDivElement | null>(null);
+  const cursorRef = useRef<HTMLDivElement | null>(null);
+  const lyricHighlightRef = useRef<HTMLDivElement | null>(null);
+  const overlayLayerRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const slotHighlightRef = useRef<HTMLDivElement | null>(null);
   const svgLayerRef = useRef<HTMLDivElement | null>(null);
+  const autoScrollGuardUntilRef = useRef(0);
+  const followPlaybackRef = useRef(followPlayback);
+  const isPlayingRef = useRef(isPlaying);
   const [measureLayouts, setMeasureLayouts] = useState<MeasureLayout[]>([]);
   const measures = useMemo(() => toMeasures(score), [score]);
   const lineHeight = showLyrics ? LINE_HEIGHT_WITH_LYRICS : LINE_HEIGHT_WITHOUT_LYRICS;
@@ -92,19 +103,27 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
     [audioCurrentTime, measures.length, score.bpm],
   );
   const activeLayout = measureLayouts[playbackPosition.measure - 1] ?? null;
-  const activeMeasure = measures[playbackPosition.measure - 1] ?? null;
-  const activeSlot = activeMeasure?.slots[playbackPosition.slot] ?? null;
-  const activeLyric = showLyrics
-    ? (activeSlot?.lyrics[0]?.lyric?.trim().normalize("NFC") ??
-      activeSlot?.lyric?.trim().normalize("NFC") ??
-      null)
-    : null;
-  const cursorX = activeLayout
-    ? activeLayout.gridStartX +
-      (playbackPosition.slotProgress / SLOTS_PER_MEASURE) * (activeLayout.gridEndX - activeLayout.gridStartX)
-    : 0;
-  const activeSlotLeft = activeLayout ? activeLayout.gridStartX + playbackPosition.slot * activeLayout.slotWidth : 0;
-  const activeSlotHeight = activeLayout ? activeLayout.bottom - activeLayout.top : 0;
+
+  useEffect(() => {
+    followPlaybackRef.current = followPlayback;
+  }, [followPlayback]);
+
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  }, [isPlaying]);
+
+  const disableFollowPlayback = useCallback(
+    (ignoreGuard: boolean) => {
+      if (!followPlaybackRef.current || !isPlayingRef.current) {
+        return;
+      }
+      if (!ignoreGuard && performance.now() <= autoScrollGuardUntilRef.current) {
+        return;
+      }
+      onFollowPlaybackChange?.(false);
+    },
+    [onFollowPlaybackChange],
+  );
 
   useImperativeHandle(
     ref,
@@ -183,10 +202,11 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
     const layout = activeLayout;
     const board = boardRef.current;
     const scrollContainer = scrollRef.current;
-    if (!layout || !board || !scrollContainer) {
+    if (!followPlayback || !layout || !board || !scrollContainer) {
       return;
     }
 
+    autoScrollGuardUntilRef.current = performance.now() + AUTO_SCROLL_GUARD_MS;
     const centerX = layout.gridStartX + (layout.gridEndX - layout.gridStartX) / 2;
     const targetLeft = Math.max(0, centerX - scrollContainer.clientWidth / 2);
     scrollContainer.scrollTo({ left: targetLeft, behavior: "smooth" });
@@ -197,7 +217,81 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
     if (Math.abs(targetTop - window.scrollY) > 80) {
       window.scrollTo({ top: targetTop, behavior: "smooth" });
     }
-  }, [activeLayout, playbackPosition.measure]);
+  }, [activeLayout, followPlayback, isPlaying, playbackPosition.measure]);
+
+  useEffect(() => {
+    let frame = 0;
+    frame = requestAnimationFrame(() => {
+      const overlayLayer = overlayLayerRef.current;
+      const slotHighlight = slotHighlightRef.current;
+      const cursor = cursorRef.current;
+      const lyricHighlight = lyricHighlightRef.current;
+      const layout = measureLayouts[playbackPosition.measure - 1] ?? null;
+      const measure = measures[playbackPosition.measure - 1] ?? null;
+      const slot = measure?.slots[playbackPosition.slot] ?? null;
+      const lyric = showLyrics
+        ? (slot?.lyrics[0]?.lyric?.trim().normalize("NFC") ?? slot?.lyric?.trim().normalize("NFC") ?? null)
+        : null;
+
+      if (!overlayLayer || !slotHighlight || !cursor || !lyricHighlight) {
+        return;
+      }
+
+      if (!layout) {
+        overlayLayer.style.opacity = "0";
+        lyricHighlight.style.opacity = "0";
+        return;
+      }
+
+      const cursorX =
+        layout.gridStartX + (playbackPosition.slotProgress / SLOTS_PER_MEASURE) * (layout.gridEndX - layout.gridStartX);
+      const activeSlotLeft = layout.gridStartX + playbackPosition.slot * layout.slotWidth;
+      const activeSlotHeight = layout.bottom - layout.top;
+
+      overlayLayer.style.opacity = "1";
+      slotHighlight.style.height = `${activeSlotHeight}px`;
+      slotHighlight.style.width = `${layout.slotWidth}px`;
+      slotHighlight.style.transform = `translate(${activeSlotLeft}px, ${layout.top}px)`;
+
+      cursor.style.height = `${activeSlotHeight}px`;
+      cursor.style.transform = `translate(${cursorX}px, ${layout.top}px)`;
+
+      if (lyric) {
+        lyricHighlight.textContent = lyric;
+        lyricHighlight.style.opacity = "1";
+        lyricHighlight.style.transform = `translate(${cursorX}px, ${layout.bottom - 28}px)`;
+      } else {
+        lyricHighlight.textContent = "";
+        lyricHighlight.style.opacity = "0";
+      }
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [measureLayouts, measures, playbackPosition, showLyrics]);
+
+  useEffect(() => {
+    const scrollContainer = scrollRef.current;
+    if (!scrollContainer) {
+      return;
+    }
+
+    const handleWindowScroll = () => disableFollowPlayback(false);
+    const handleContainerScroll = () => disableFollowPlayback(false);
+    const handleWindowWheel = () => disableFollowPlayback(true);
+    const handleTouchStart = () => disableFollowPlayback(true);
+
+    window.addEventListener("scroll", handleWindowScroll, { passive: true });
+    window.addEventListener("wheel", handleWindowWheel, { passive: true });
+    scrollContainer.addEventListener("scroll", handleContainerScroll, { passive: true });
+    scrollContainer.addEventListener("touchstart", handleTouchStart, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleWindowScroll);
+      window.removeEventListener("wheel", handleWindowWheel);
+      scrollContainer.removeEventListener("scroll", handleContainerScroll);
+      scrollContainer.removeEventListener("touchstart", handleTouchStart);
+    };
+  }, [disableFollowPlayback]);
 
   function handleBoardClick(event: React.MouseEvent<HTMLDivElement>) {
     if (!onSeek || !boardRef.current) {
@@ -238,35 +332,11 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
           tabIndex={onSeek ? 0 : undefined}
         >
           <div className="score-svg-layer" ref={svgLayerRef} />
-          {activeLayout ? (
-            <div className="score-overlay-layer" aria-hidden="true">
-              <div
-                className="playback-slot-highlight"
-                style={{
-                  height: activeSlotHeight,
-                  transform: `translate(${activeSlotLeft}px, ${activeLayout.top}px)`,
-                  width: activeLayout.slotWidth,
-                }}
-              />
-              <div
-                className="playback-cursor"
-                style={{
-                  height: activeSlotHeight,
-                  transform: `translate(${cursorX}px, ${activeLayout.top}px)`,
-                }}
-              />
-              {activeLyric ? (
-                <div
-                  className="playback-lyric-highlight"
-                  style={{
-                    transform: `translate(${cursorX}px, ${activeLayout.bottom - 28}px)`,
-                  }}
-                >
-                  {activeLyric}
-                </div>
-              ) : null}
-            </div>
-          ) : null}
+          <div className="score-overlay-layer" aria-hidden="true" ref={overlayLayerRef}>
+            <div className="playback-slot-highlight" ref={slotHighlightRef} />
+            <div className="playback-cursor" ref={cursorRef} />
+            <div className="playback-lyric-highlight" ref={lyricHighlightRef} />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/components/SynchronizedScorePlayer.tsx
+++ b/apps/web/components/SynchronizedScorePlayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { AnalysisResult } from "@/lib/types";
 
 export type PlaybackSource =
@@ -24,6 +24,9 @@ export type SynchronizedScorePlayerHandle = {
 
 type Props = {
   currentTime: number;
+  followPlayback: boolean;
+  onFollowPlaybackChange: (enabled: boolean) => void;
+  onPlaybackStateChange?: (playing: boolean) => void;
   onTimeChange: (time: number) => void;
   score: AnalysisResult;
   source: PlaybackSource;
@@ -69,17 +72,51 @@ const YOUTUBE_ENDED = 0;
 let youtubeApiPromise: Promise<YouTubeApi> | null = null;
 
 export const SynchronizedScorePlayer = forwardRef<SynchronizedScorePlayerHandle, Props>(
-  function SynchronizedScorePlayer({ currentTime, onTimeChange, score, source }, ref) {
+  function SynchronizedScorePlayer(
+    { currentTime, followPlayback, onFollowPlaybackChange, onPlaybackStateChange, onTimeChange, score, source },
+    ref,
+  ) {
     const audioRef = useRef<HTMLAudioElement | null>(null);
     const volumeRef = useRef(0.85);
     const youtubeMountRef = useRef<HTMLDivElement | null>(null);
     const youtubePlayerRef = useRef<YouTubePlayer | null>(null);
+    const playbackLoopFrameRef = useRef<number | null>(null);
     const [duration, setDuration] = useState(0);
     const [isPlaying, setIsPlaying] = useState(false);
     const [volume, setVolume] = useState(0.85);
     const sourceKey = source.kind === "youtube" ? `youtube:${source.videoId}` : `audio:${source.url}`;
     const scoreDuration = useMemo(() => estimateScoreDuration(score), [score]);
     const playbackDuration = duration > 0 ? duration : scoreDuration;
+
+    const publishPlaybackSnapshot = useCallback(() => {
+      const nextTime = readCurrentTime(source, audioRef.current, youtubePlayerRef.current);
+      if (Number.isFinite(nextTime)) {
+        onTimeChange(nextTime);
+      }
+
+      const nextDuration = readDuration(source, audioRef.current, youtubePlayerRef.current);
+      if (Number.isFinite(nextDuration) && nextDuration > 0) {
+        setDuration((current) => (Math.abs(current - nextDuration) > 0.25 ? nextDuration : current));
+      }
+    }, [onTimeChange, source]);
+
+    const stopPlaybackLoop = useCallback(() => {
+      if (playbackLoopFrameRef.current !== null) {
+        cancelAnimationFrame(playbackLoopFrameRef.current);
+        playbackLoopFrameRef.current = null;
+      }
+    }, []);
+
+    const startPlaybackLoop = useCallback(() => {
+      stopPlaybackLoop();
+
+      const tick = () => {
+        publishPlaybackSnapshot();
+        playbackLoopFrameRef.current = requestAnimationFrame(tick);
+      };
+
+      playbackLoopFrameRef.current = requestAnimationFrame(tick);
+    }, [publishPlaybackSnapshot, stopPlaybackLoop]);
 
     useEffect(() => {
       volumeRef.current = volume;
@@ -103,8 +140,13 @@ export const SynchronizedScorePlayer = forwardRef<SynchronizedScorePlayerHandle,
     useEffect(() => {
       setIsPlaying(false);
       setDuration(0);
+      stopPlaybackLoop();
       onTimeChange(0);
-    }, [onTimeChange, sourceKey]);
+    }, [onTimeChange, sourceKey, stopPlaybackLoop]);
+
+    useEffect(() => {
+      onPlaybackStateChange?.(isPlaying);
+    }, [isPlaying, onPlaybackStateChange]);
 
     useEffect(() => {
       if (source.kind !== "audio") {
@@ -131,6 +173,7 @@ export const SynchronizedScorePlayer = forwardRef<SynchronizedScorePlayerHandle,
       if (source.kind !== "youtube") {
         youtubePlayerRef.current?.destroy();
         youtubePlayerRef.current = null;
+        stopPlaybackLoop();
         return;
       }
 
@@ -164,14 +207,19 @@ export const SynchronizedScorePlayer = forwardRef<SynchronizedScorePlayerHandle,
               if (Number.isFinite(nextDuration) && nextDuration > 0) {
                 setDuration(nextDuration);
               }
+              publishPlaybackSnapshot();
             },
             onStateChange: (event) => {
               if (event.data === YOUTUBE_PLAYING) {
                 setIsPlaying(true);
+                startPlaybackLoop();
+                publishPlaybackSnapshot();
                 return;
               }
               if (event.data === YOUTUBE_PAUSED || event.data === YOUTUBE_ENDED) {
                 setIsPlaying(false);
+                stopPlaybackLoop();
+                publishPlaybackSnapshot();
               }
             },
           },
@@ -181,38 +229,23 @@ export const SynchronizedScorePlayer = forwardRef<SynchronizedScorePlayerHandle,
 
       return () => {
         disposed = true;
+        stopPlaybackLoop();
         youtubePlayerRef.current?.destroy();
         youtubePlayerRef.current = null;
       };
-    }, [source]);
-
-    useEffect(() => {
-      let frame = 0;
-      const tick = () => {
-        const nextTime = readCurrentTime(source, audioRef.current, youtubePlayerRef.current);
-        if (Number.isFinite(nextTime)) {
-          onTimeChange(nextTime);
-        }
-
-        const nextDuration = readDuration(source, audioRef.current, youtubePlayerRef.current);
-        if (Number.isFinite(nextDuration) && nextDuration > 0) {
-          setDuration((current) => (Math.abs(current - nextDuration) > 0.25 ? nextDuration : current));
-        }
-
-        frame = requestAnimationFrame(tick);
-      };
-
-      frame = requestAnimationFrame(tick);
-      return () => cancelAnimationFrame(frame);
-    }, [onTimeChange, source]);
+    }, [publishPlaybackSnapshot, source, startPlaybackLoop, stopPlaybackLoop]);
 
     function togglePlayback() {
       if (isPlaying) {
         pauseSource(source, audioRef.current, youtubePlayerRef.current);
+        stopPlaybackLoop();
         return;
       }
 
       void playSource(source, audioRef.current, youtubePlayerRef.current);
+      if (source.kind === "audio") {
+        startPlaybackLoop();
+      }
     }
 
     function seekTo(seconds: number) {
@@ -228,19 +261,41 @@ export const SynchronizedScorePlayer = forwardRef<SynchronizedScorePlayerHandle,
             <div className="player-kicker">{source.kind === "youtube" ? "YouTube source" : "Uploaded audio"}</div>
             <div className="player-title">{source.title}</div>
           </div>
-          <button className="player-button" onClick={togglePlayback} type="button">
-            {isPlaying ? "Pause" : "Play"}
-          </button>
+          <div className="player-actions">
+            <button className="player-button" onClick={togglePlayback} type="button">
+              {isPlaying ? "Pause" : "Play"}
+            </button>
+            <button
+              aria-pressed={followPlayback}
+              className={followPlayback ? "player-button player-follow-button active" : "player-button player-follow-button"}
+              onClick={() => onFollowPlaybackChange(!followPlayback)}
+              type="button"
+            >
+              {followPlayback ? "Follow On" : "Follow Off"}
+            </button>
+          </div>
         </div>
 
         {source.kind === "audio" ? (
           <audio
             ref={audioRef}
             onDurationChange={(event) => setDuration(safeDuration(event.currentTarget.duration))}
-            onEnded={() => setIsPlaying(false)}
+            onEnded={() => {
+              setIsPlaying(false);
+              stopPlaybackLoop();
+              publishPlaybackSnapshot();
+            }}
             onLoadedMetadata={(event) => setDuration(safeDuration(event.currentTarget.duration))}
-            onPause={() => setIsPlaying(false)}
-            onPlay={() => setIsPlaying(true)}
+            onPause={() => {
+              setIsPlaying(false);
+              stopPlaybackLoop();
+              publishPlaybackSnapshot();
+            }}
+            onPlay={() => {
+              setIsPlaying(true);
+              startPlaybackLoop();
+            }}
+            onSeeked={publishPlaybackSnapshot}
             preload="metadata"
             src={source.url}
           />


### PR DESCRIPTION
## 변경 내용 요약
- 동기화 재생 화면에 Follow On/Off 토글을 추가했습니다.
- 사용자가 수동 스크롤하거나 seek할 때 자동 스크롤이 즉시 되살아나지 않도록 DrumSheet follow 로직을 다듬었습니다.
- 재생 중인 슬롯/가사 하이라이트는 오버레이 DOM을 재사용해 더 안정적으로 갱신합니다.

## 변경 이유
- 재생 위치를 자동으로 따라가는 기능은 유용하지만, 사용자가 악보를 직접 탐색할 때는 방해가 될 수 있습니다.
- 재생 상태, follow 상태, 수동 스크롤을 분리해 다뤄야 악보 검수 흐름이 자연스럽습니다.

## 주요 변경 사항
- `SynchronizedScorePlayer`에 Follow On/Off 버튼과 playback state 콜백을 추가했습니다.
- `DrumSheet`는 follow 상태와 재생 상태를 받아 자동 스크롤을 제어하고, 수동 스크롤/휠/터치 이후에는 follow를 해제합니다.
- 자동 스크롤 직후 사용자의 이벤트를 무시하는 짧은 guard 시간을 두어 즉시 follow가 꺼지는 현상을 막았습니다.
- 재생 오버레이는 매 렌더마다 새 DOM을 만들지 않고 ref 기반으로 위치/가시성만 갱신합니다.
- 페이지는 분석 완료 시 follow를 기본 활성화하고, 재생 활성 상태를 별도 상태로 관리합니다.

## 테스트 방법
- `git diff --check`
- `git diff --cached --check`
- `npm --workspace apps/web run lint`
- `npm --workspace apps/web run build`
- `py -3 harness\beatly_quality_harness.py`는 실행하지 못했습니다. 이 환경에는 `py`, `python`, `python3` 명령이 없고 `harness\beatly_quality_harness.py` 파일도 없습니다.
