### PR TITLE
[FE] 드럼 악보 페이지 뷰와 기보 가독성 개선

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -270,29 +270,92 @@ input {
 
 .score-wrap {
   margin-top: 18px;
-  overflow-x: auto;
-  background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 8px;
+  display: grid;
+  gap: 12px;
 }
 
-.score-canvas {
-  min-width: 920px;
-  padding: 16px 12px 8px;
+.score-book-shell {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.score-book-viewport {
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  overscroll-behavior-x: contain;
+}
+
+.score-page-strip {
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+}
+
+.score-page-shell {
+  flex: 0 0 min(210mm, calc(100vw - 176px));
+  scroll-snap-align: center;
+}
+
+.score-page-sheet {
+  width: 100%;
+  aspect-ratio: 210 / 297;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 12px 28px rgba(17, 19, 23, 0.08);
+}
+
+.score-page-indicator {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.score-page-nav {
+  min-width: 76px;
+  min-height: 44px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--ink);
+  background: #fff;
+  cursor: pointer;
+}
+
+.score-page-nav:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .score-board {
   position: relative;
-  display: inline-block;
+  width: 100%;
+  height: 100%;
 }
 
 .score-board.seekable {
   cursor: pointer;
 }
 
+.score-page-board {
+  overflow: hidden;
+}
+
 .score-svg-layer {
+  width: 100%;
+  height: 100%;
   position: relative;
   z-index: 1;
+}
+
+.score-svg-layer svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .score-overlay-layer {
@@ -348,6 +411,18 @@ input {
 @media (max-width: 720px) {
   .page {
     padding: 20px 14px;
+  }
+
+  .score-book-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .score-page-shell {
+    flex-basis: calc(100vw - 28px);
+  }
+
+  .score-page-nav {
+    width: 100%;
   }
 
   .topbar {

--- a/apps/web/components/DrumSheet.tsx
+++ b/apps/web/components/DrumSheet.tsx
@@ -40,8 +40,14 @@ type MeasureLayout = {
   gridEndX: number;
   gridStartX: number;
   measure: number;
+  pageIndex: number;
   slotWidth: number;
   top: number;
+};
+type PageDescriptor = {
+  measureEnd: number;
+  measureStart: number;
+  measures: Measure[];
 };
 type PlaybackPosition = {
   measure: number;
@@ -69,13 +75,16 @@ const NOTE_MAP: Record<DrumNote, { key: string; voice: VoiceNumber; notehead: "n
   kick: { key: "f/4", voice: 2, notehead: "normal", order: 6 },
 };
 
-const MEASURES_PER_LINE = 4;
-const MEASURE_WIDTH = 320;
-const LEFT_MARGIN = 28;
-const TOP_MARGIN = 26;
+const PAGE_HEIGHT_PX = 1123;
+const PAGE_PADDING_X = 24;
+const PAGE_PADDING_Y = 34;
+const PAGE_WIDTH_PX = 794;
 const LINE_HEIGHT_WITH_LYRICS = 178;
 const LINE_HEIGHT_WITHOUT_LYRICS = 142;
 const SLOTS_PER_MEASURE = 16;
+const MIN_SLOT_WIDTH_PX = 40;
+const FIRST_MEASURE_RESERVE_PX = 76;
+const REGULAR_MEASURE_RESERVE_PX = 24;
 const LYRIC_FONT_SIZE = 12;
 const LYRIC_HORIZONTAL_PADDING_PX = 5;
 const LYRIC_MAX_ROWS = 2;
@@ -85,24 +94,38 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
   { audioCurrentTime = 0, followPlayback = true, isPlaying = false, onFollowPlaybackChange, onSeek, score, showLyrics = true }: Props,
   ref,
 ) {
-  const boardRef = useRef<HTMLDivElement | null>(null);
-  const cursorRef = useRef<HTMLDivElement | null>(null);
-  const lyricHighlightRef = useRef<HTMLDivElement | null>(null);
-  const overlayLayerRef = useRef<HTMLDivElement | null>(null);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const slotHighlightRef = useRef<HTMLDivElement | null>(null);
-  const svgLayerRef = useRef<HTMLDivElement | null>(null);
+  const boardRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const cursorRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const lyricHighlightRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const overlayLayerRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const pageRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const slotHighlightRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const svgLayerRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
   const autoScrollGuardUntilRef = useRef(0);
   const followPlaybackRef = useRef(followPlayback);
   const isPlayingRef = useRef(isPlaying);
   const [measureLayouts, setMeasureLayouts] = useState<MeasureLayout[]>([]);
+  const [visiblePageIndex, setVisiblePageIndex] = useState(0);
   const measures = useMemo(() => toMeasures(score), [score]);
   const lineHeight = showLyrics ? LINE_HEIGHT_WITH_LYRICS : LINE_HEIGHT_WITHOUT_LYRICS;
+  const pagination = useMemo(() => paginateMeasures(measures, score.bpm, showLyrics), [measures, score.bpm, showLyrics]);
+  const pages = pagination.pages;
+  const measuresPerLine = pagination.measuresPerLine;
+  const measuresPerPage = pagination.measuresPerPage;
+  const measureWidth = pagination.measureWidth;
   const playbackPosition = useMemo(
     () => timeToPlaybackPosition(audioCurrentTime, score.bpm, measures.length),
     [audioCurrentTime, measures.length, score.bpm],
   );
   const activeLayout = measureLayouts[playbackPosition.measure - 1] ?? null;
+  const targetPageIndex = useMemo(
+    () =>
+      pages.length > 0
+        ? clamp(Math.floor(Math.max(0, playbackPosition.measure - 1) / Math.max(1, measuresPerPage)), 0, pages.length - 1)
+        : 0,
+    [measuresPerPage, pages.length, playbackPosition.measure],
+  );
 
   useEffect(() => {
     followPlaybackRef.current = followPlayback;
@@ -128,104 +151,94 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
   useImperativeHandle(
     ref,
     () => ({
-      getPrintableSystems: () => collectPrintableSystems(svgLayerRef.current, measureLayouts),
+      getPrintableSystems: () => collectPrintableSystems(svgLayerRefs.current, pages),
     }),
-    [measureLayouts],
+    [pages],
   );
 
   useEffect(() => {
-    const container = svgLayerRef.current;
-    if (!container) {
-      return;
-    }
-
-    container.innerHTML = "";
-
-    const width = LEFT_MARGIN * 2 + MEASURES_PER_LINE * MEASURE_WIDTH;
-    const height = Math.max(240, Math.ceil(measures.length / MEASURES_PER_LINE) * lineHeight + TOP_MARGIN);
-    const renderer = new Renderer(container, Renderer.Backends.SVG);
-    renderer.resize(width, height);
-
-    const context = renderer.getContext();
-    context.setFont("Arial, Malgun Gothic, sans-serif", 12);
     const nextLayouts: MeasureLayout[] = [];
 
-    measures.forEach((measure, index) => {
-      const column = index % MEASURES_PER_LINE;
-      const row = Math.floor(index / MEASURES_PER_LINE);
-      const x = LEFT_MARGIN + column * MEASURE_WIDTH;
-      const y = TOP_MARGIN + row * lineHeight;
-      const staveWidth = MEASURE_WIDTH;
-
-      const stave = new Stave(x, y, staveWidth);
-      if (index === 0) {
-        stave.addClef("percussion").addTimeSignature("4/4");
+    pages.forEach((page, pageIndex) => {
+      const container = svgLayerRefs.current[pageIndex];
+      if (!container) {
+        return;
       }
-      stave.setContext(context).draw();
-      drawMeasureNumber(context, index + 1, x, y);
 
-      const upperTicks = simplifyVoice(measure, 1);
-      const lowerTicks = simplifyVoice(measure, 2);
-      const upperNotes = upperTicks.map((tick) => makeVoiceNote(tick, 1));
-      const lowerNotes = lowerTicks.map((tick) => makeVoiceNote(tick, 2));
-      const upperVoice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
-      const lowerVoice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
+      container.innerHTML = "";
 
-      upperVoice.addTickables(upperNotes);
-      lowerVoice.addTickables(lowerNotes);
+      const renderer = new Renderer(container, Renderer.Backends.SVG);
+      renderer.resize(PAGE_WIDTH_PX, PAGE_HEIGHT_PX);
 
-      new Formatter()
-        .joinVoices([upperVoice, lowerVoice])
-        .format([upperVoice, lowerVoice], staveWidth - (index === 0 ? 76 : 24));
+      const context = renderer.getContext();
+      context.setFont("Arial, Malgun Gothic, sans-serif", 12);
 
-      prepareStraightBeamStems(upperNotes, upperTicks, 1);
+      page.measures.forEach((measure, localIndex) => {
+        const globalIndex = page.measureStart - 1 + localIndex;
+        const column = localIndex % measuresPerLine;
+        const row = Math.floor(localIndex / measuresPerLine);
+        const x = PAGE_PADDING_X + column * measureWidth;
+        const y = PAGE_PADDING_Y + row * lineHeight;
+        const staveWidth = measureWidth;
 
-      upperVoice.draw(context, stave);
-      lowerVoice.draw(context, stave);
+        const stave = new Stave(x, y, staveWidth);
+        if (localIndex === 0) {
+          stave.addClef("percussion").addTimeSignature("4/4");
+        }
+        stave.setContext(context).draw();
+        drawMeasureNumber(context, globalIndex + 1, x, y);
 
-      drawStraightBeams(context, upperNotes, upperTicks, 1);
+        const upperTicks = simplifyVoice(measure, 1);
+        const lowerTicks = simplifyVoice(measure, 2);
+        const upperNotes = upperTicks.map((tick) => makeVoiceNote(tick, 1));
+        const lowerNotes = lowerTicks.map((tick) => makeVoiceNote(tick, 2));
+        const upperVoice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
+        const lowerVoice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
 
-      upperTicks.forEach((tick, tickIndex) => {
-        drawHiHatStateMarks(context, upperNotes[tickIndex], tick);
-        drawGhostSnareMarks(context, upperNotes[tickIndex], tick);
+        upperVoice.addTickables(upperNotes);
+        lowerVoice.addTickables(lowerNotes);
+
+        const formatterWidth = staveWidth - (localIndex === 0 ? FIRST_MEASURE_RESERVE_PX : REGULAR_MEASURE_RESERVE_PX);
+        new Formatter().joinVoices([upperVoice, lowerVoice]).format([upperVoice, lowerVoice], formatterWidth);
+
+        prepareStraightBeamStems(upperNotes, upperTicks, 1);
+
+        upperVoice.draw(context, stave);
+        lowerVoice.draw(context, stave);
+
+        drawStraightBeams(context, upperNotes, upperTicks, 1);
+        drawCustomXNoteheads(context, upperNotes, upperTicks);
+
+        upperTicks.forEach((tick, tickIndex) => {
+          drawHiHatStateMarks(context, upperNotes[tickIndex], tick);
+          drawGhostSnareMarks(context, upperNotes[tickIndex], tick);
+        });
+        if (showLyrics) {
+          drawLyricLane(context, stave, measure);
+        }
+        nextLayouts[globalIndex] = measureLayoutFromStave(stave, globalIndex + 1, pageIndex, showLyrics);
       });
-      if (showLyrics) {
-        drawLyricLane(context, stave, measure);
-      }
-      nextLayouts.push(measureLayoutFromStave(stave, index + 1, showLyrics));
     });
 
     setMeasureLayouts(nextLayouts);
-  }, [lineHeight, measures, showLyrics]);
-
-  useEffect(() => {
-    const layout = activeLayout;
-    const board = boardRef.current;
-    const scrollContainer = scrollRef.current;
-    if (!followPlayback || !layout || !board || !scrollContainer) {
-      return;
-    }
-
-    autoScrollGuardUntilRef.current = performance.now() + AUTO_SCROLL_GUARD_MS;
-    const centerX = layout.gridStartX + (layout.gridEndX - layout.gridStartX) / 2;
-    const targetLeft = Math.max(0, centerX - scrollContainer.clientWidth / 2);
-    scrollContainer.scrollTo({ left: targetLeft, behavior: "smooth" });
-
-    const boardRect = board.getBoundingClientRect();
-    const centerY = boardRect.top + (layout.top + layout.bottom) / 2;
-    const targetTop = Math.max(0, window.scrollY + centerY - window.innerHeight / 2);
-    if (Math.abs(targetTop - window.scrollY) > 80) {
-      window.scrollTo({ top: targetTop, behavior: "smooth" });
-    }
-  }, [activeLayout, followPlayback, isPlaying, playbackPosition.measure]);
+  }, [lineHeight, measureWidth, measuresPerLine, pages, showLyrics]);
 
   useEffect(() => {
     let frame = 0;
     frame = requestAnimationFrame(() => {
-      const overlayLayer = overlayLayerRef.current;
-      const slotHighlight = slotHighlightRef.current;
-      const cursor = cursorRef.current;
-      const lyricHighlight = lyricHighlightRef.current;
+      const activePageIndex = activeLayout?.pageIndex ?? -1;
+
+      overlayLayerRefs.current.forEach((overlayLayer, pageIndex) => {
+        if (overlayLayer) {
+          overlayLayer.style.opacity = pageIndex === activePageIndex ? "1" : "0";
+        }
+      });
+
+      const overlayLayer = activePageIndex >= 0 ? overlayLayerRefs.current[activePageIndex] : null;
+      const slotHighlight = activePageIndex >= 0 ? slotHighlightRefs.current[activePageIndex] : null;
+      const cursor = activePageIndex >= 0 ? cursorRefs.current[activePageIndex] : null;
+      const lyricHighlight = activePageIndex >= 0 ? lyricHighlightRefs.current[activePageIndex] : null;
+      const board = activePageIndex >= 0 ? boardRefs.current[activePageIndex] : null;
       const layout = measureLayouts[playbackPosition.measure - 1] ?? null;
       const measure = measures[playbackPosition.measure - 1] ?? null;
       const slot = measure?.slots[playbackPosition.slot] ?? null;
@@ -233,7 +246,7 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
         ? (slot?.lyrics[0]?.lyric?.trim().normalize("NFC") ?? slot?.lyric?.trim().normalize("NFC") ?? null)
         : null;
 
-      if (!overlayLayer || !slotHighlight || !cursor || !lyricHighlight) {
+      if (!overlayLayer || !slotHighlight || !cursor || !lyricHighlight || !board) {
         return;
       }
 
@@ -247,19 +260,22 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
         layout.gridStartX + (playbackPosition.slotProgress / SLOTS_PER_MEASURE) * (layout.gridEndX - layout.gridStartX);
       const activeSlotLeft = layout.gridStartX + playbackPosition.slot * layout.slotWidth;
       const activeSlotHeight = layout.bottom - layout.top;
+      const boardRect = board.getBoundingClientRect();
+      const scaleX = boardRect.width / PAGE_WIDTH_PX;
+      const scaleY = boardRect.height / PAGE_HEIGHT_PX;
 
       overlayLayer.style.opacity = "1";
-      slotHighlight.style.height = `${activeSlotHeight}px`;
-      slotHighlight.style.width = `${layout.slotWidth}px`;
-      slotHighlight.style.transform = `translate(${activeSlotLeft}px, ${layout.top}px)`;
+      slotHighlight.style.height = `${activeSlotHeight * scaleY}px`;
+      slotHighlight.style.width = `${layout.slotWidth * scaleX}px`;
+      slotHighlight.style.transform = `translate(${activeSlotLeft * scaleX}px, ${layout.top * scaleY}px)`;
 
-      cursor.style.height = `${activeSlotHeight}px`;
-      cursor.style.transform = `translate(${cursorX}px, ${layout.top}px)`;
+      cursor.style.height = `${activeSlotHeight * scaleY}px`;
+      cursor.style.transform = `translate(${cursorX * scaleX}px, ${layout.top * scaleY}px)`;
 
       if (lyric) {
         lyricHighlight.textContent = lyric;
         lyricHighlight.style.opacity = "1";
-        lyricHighlight.style.transform = `translate(${cursorX}px, ${layout.bottom - 28}px)`;
+        lyricHighlight.style.transform = `translate(${cursorX * scaleX}px, ${(layout.bottom - 28) * scaleY}px)`;
       } else {
         lyricHighlight.textContent = "";
         lyricHighlight.style.opacity = "0";
@@ -267,41 +283,145 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
     });
 
     return () => cancelAnimationFrame(frame);
-  }, [measureLayouts, measures, playbackPosition, showLyrics]);
+  }, [activeLayout, measureLayouts, measures, playbackPosition, showLyrics]);
 
   useEffect(() => {
-    const scrollContainer = scrollRef.current;
-    if (!scrollContainer) {
+    const viewport = viewportRef.current;
+    if (!viewport) {
       return;
     }
 
+    let frame = 0;
+    const updateVisiblePage = () => {
+      if (!viewportRef.current || pages.length === 0) {
+        return;
+      }
+      const viewportCenter = viewportRef.current.scrollLeft + viewportRef.current.clientWidth / 2;
+      let nextIndex = 0;
+      let nextDistance = Number.POSITIVE_INFINITY;
+      pageRefs.current.forEach((page, pageIndex) => {
+        if (!page) {
+          return;
+        }
+        const center = page.offsetLeft + page.clientWidth / 2;
+        const distance = Math.abs(center - viewportCenter);
+        if (distance < nextDistance) {
+          nextDistance = distance;
+          nextIndex = pageIndex;
+        }
+      });
+      setVisiblePageIndex((current) => (current === nextIndex ? current : nextIndex));
+    };
+
     const handleWindowScroll = () => disableFollowPlayback(false);
-    const handleContainerScroll = () => disableFollowPlayback(false);
+    const handleViewportScroll = () => {
+      disableFollowPlayback(false);
+      if (frame) {
+        cancelAnimationFrame(frame);
+      }
+      frame = requestAnimationFrame(updateVisiblePage);
+    };
     const handleWindowWheel = () => disableFollowPlayback(true);
     const handleTouchStart = () => disableFollowPlayback(true);
 
+    updateVisiblePage();
     window.addEventListener("scroll", handleWindowScroll, { passive: true });
     window.addEventListener("wheel", handleWindowWheel, { passive: true });
-    scrollContainer.addEventListener("scroll", handleContainerScroll, { passive: true });
-    scrollContainer.addEventListener("touchstart", handleTouchStart, { passive: true });
+    viewport.addEventListener("scroll", handleViewportScroll, { passive: true });
+    viewport.addEventListener("touchstart", handleTouchStart, { passive: true });
 
     return () => {
+      if (frame) {
+        cancelAnimationFrame(frame);
+      }
       window.removeEventListener("scroll", handleWindowScroll);
       window.removeEventListener("wheel", handleWindowWheel);
-      scrollContainer.removeEventListener("scroll", handleContainerScroll);
-      scrollContainer.removeEventListener("touchstart", handleTouchStart);
+      viewport.removeEventListener("scroll", handleViewportScroll);
+      viewport.removeEventListener("touchstart", handleTouchStart);
     };
-  }, [disableFollowPlayback]);
+  }, [disableFollowPlayback, pages.length]);
 
-  function handleBoardClick(event: React.MouseEvent<HTMLDivElement>) {
-    if (!onSeek || !boardRef.current) {
+  useEffect(() => {
+    setVisiblePageIndex((current) => Math.min(current, Math.max(0, pages.length - 1)));
+    boardRefs.current = boardRefs.current.slice(0, pages.length);
+    cursorRefs.current = cursorRefs.current.slice(0, pages.length);
+    lyricHighlightRefs.current = lyricHighlightRefs.current.slice(0, pages.length);
+    overlayLayerRefs.current = overlayLayerRefs.current.slice(0, pages.length);
+    pageRefs.current = pageRefs.current.slice(0, pages.length);
+    slotHighlightRefs.current = slotHighlightRefs.current.slice(0, pages.length);
+    svgLayerRefs.current = svgLayerRefs.current.slice(0, pages.length);
+  }, [pages.length]);
+
+  const getPageScrollLeft = useCallback((pageIndex: number) => {
+    const viewport = viewportRef.current;
+    const firstPage = pageRefs.current[0];
+    const targetPage = pageRefs.current[pageIndex];
+    if (!viewport || !targetPage) {
+      return 0;
+    }
+    if (pageIndex <= 0 || !firstPage) {
+      return 0;
+    }
+
+    const secondPage = pageRefs.current[1];
+    const pageStride =
+      secondPage && firstPage ? secondPage.offsetLeft - firstPage.offsetLeft : firstPage.offsetWidth;
+    return Math.max(0, pageStride * pageIndex);
+  }, []);
+
+  const scrollToPage = useCallback((pageIndex: number, behavior: ScrollBehavior = "smooth") => {
+    const viewport = viewportRef.current;
+    if (!viewport || !pageRefs.current[pageIndex]) {
       return;
     }
 
-    const rect = boardRef.current.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
-    const layout = findMeasureLayoutAtPoint(measureLayouts, x, y);
+    autoScrollGuardUntilRef.current = performance.now() + AUTO_SCROLL_GUARD_MS;
+    const targetLeft = getPageScrollLeft(pageIndex);
+    viewport.scrollTo({ left: targetLeft, behavior });
+    setVisiblePageIndex((current) => (current === pageIndex ? current : pageIndex));
+  }, [getPageScrollLeft]);
+
+  useEffect(() => {
+    if (!followPlayback || pages.length === 0) {
+      return;
+    }
+
+    if (targetPageIndex !== visiblePageIndex) {
+      scrollToPage(targetPageIndex, "smooth");
+      return;
+    }
+
+    if (activeLayout && activeLayout.pageIndex !== visiblePageIndex) {
+      scrollToPage(activeLayout.pageIndex, "smooth");
+    }
+  }, [activeLayout, followPlayback, pages.length, scrollToPage, targetPageIndex, visiblePageIndex]);
+
+  function handlePageNavigation(direction: -1 | 1) {
+    const nextPageIndex = clamp(visiblePageIndex + direction, 0, Math.max(0, pages.length - 1));
+    if (nextPageIndex === visiblePageIndex) {
+      return;
+    }
+
+    disableFollowPlayback(true);
+    scrollToPage(nextPageIndex);
+  }
+
+  function handleBoardClick(pageIndex: number, event: React.MouseEvent<HTMLDivElement>) {
+    const board = boardRefs.current[pageIndex];
+    if (!onSeek || !board) {
+      return;
+    }
+
+    const rect = board.getBoundingClientRect();
+    const scaleX = PAGE_WIDTH_PX / rect.width;
+    const scaleY = PAGE_HEIGHT_PX / rect.height;
+    const x = (event.clientX - rect.left) * scaleX;
+    const y = (event.clientY - rect.top) * scaleY;
+    const layout = findMeasureLayoutAtPoint(
+      measureLayouts.filter((entry) => entry.pageIndex === pageIndex),
+      x,
+      y,
+    );
     if (!layout) {
       return;
     }
@@ -313,113 +433,181 @@ export const DrumSheet = forwardRef<DrumSheetHandle, Props>(function DrumSheet(
   }
 
   return (
-    <div className="score-wrap" ref={scrollRef} aria-label="Drum sheet with synchronized playback">
-      <div className="score-canvas">
-        <div
-          className={onSeek ? "score-board seekable" : "score-board"}
-          onClick={handleBoardClick}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              if (onSeek && activeLayout) {
-                const beatSeconds = 60 / Math.max(score.bpm || 120, 1);
-                onSeek((activeLayout.measure - 1) * beatSeconds * 4);
-              }
-            }
-          }}
-          ref={boardRef}
-          role={onSeek ? "button" : undefined}
-          tabIndex={onSeek ? 0 : undefined}
+    <div className="score-wrap" aria-label="Drum sheet with synchronized playback">
+      <div className="score-book-shell">
+        <button
+          aria-label="Previous page"
+          className="score-page-nav"
+          disabled={visiblePageIndex <= 0}
+          onClick={() => handlePageNavigation(-1)}
+          type="button"
         >
-          <div className="score-svg-layer" ref={svgLayerRef} />
-          <div className="score-overlay-layer" aria-hidden="true" ref={overlayLayerRef}>
-            <div className="playback-slot-highlight" ref={slotHighlightRef} />
-            <div className="playback-cursor" ref={cursorRef} />
-            <div className="playback-lyric-highlight" ref={lyricHighlightRef} />
+          Prev
+        </button>
+        <div className="score-book-viewport" ref={viewportRef}>
+          <div className="score-page-strip">
+            {pages.map((page, pageIndex) => (
+              <div
+                className="score-page-shell"
+                key={`page-${page.measureStart}-${page.measureEnd}`}
+                ref={(node) => {
+                  pageRefs.current[pageIndex] = node;
+                }}
+              >
+                <div className="score-page-sheet">
+                  <div
+                    className={onSeek ? "score-board seekable score-page-board" : "score-board score-page-board"}
+                    onClick={(event) => handleBoardClick(pageIndex, event)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        if (onSeek) {
+                          const beatSeconds = 60 / Math.max(score.bpm || 120, 1);
+                          onSeek((page.measureStart - 1) * beatSeconds * 4);
+                        }
+                      }
+                    }}
+                    ref={(node) => {
+                      boardRefs.current[pageIndex] = node;
+                    }}
+                    role={onSeek ? "button" : undefined}
+                    tabIndex={onSeek ? 0 : undefined}
+                  >
+                    <div
+                      className="score-svg-layer"
+                      ref={(node) => {
+                        svgLayerRefs.current[pageIndex] = node;
+                      }}
+                    />
+                    <div
+                      className="score-overlay-layer"
+                      aria-hidden="true"
+                      ref={(node) => {
+                        overlayLayerRefs.current[pageIndex] = node;
+                      }}
+                    >
+                      <div
+                        className="playback-slot-highlight"
+                        ref={(node) => {
+                          slotHighlightRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-cursor"
+                        ref={(node) => {
+                          cursorRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-lyric-highlight"
+                        ref={(node) => {
+                          lyricHighlightRefs.current[pageIndex] = node;
+                        }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
+        <button
+          aria-label="Next page"
+          className="score-page-nav"
+          disabled={visiblePageIndex >= Math.max(0, pages.length - 1)}
+          onClick={() => handlePageNavigation(1)}
+          type="button"
+        >
+          Next
+        </button>
       </div>
+      {pages.length > 0 ? (
+        <div className="score-page-indicator">
+          Page {visiblePageIndex + 1} / {pages.length}
+        </div>
+      ) : null}
     </div>
   );
 });
 
 function collectPrintableSystems(
-  container: HTMLDivElement | null,
-  layouts: MeasureLayout[],
+  containers: Array<HTMLDivElement | null>,
+  pages: PageDescriptor[],
 ): PrintableScoreSystem[] {
-  const sourceSvg = container?.querySelector("svg");
-  if (!sourceSvg || !layouts.length) {
-    return [];
-  }
-
-  const parsedViewBox = parseSvgViewBox(sourceSvg.getAttribute("viewBox"));
-  const fullWidth = parsedViewBox?.width ?? svgDimension(sourceSvg, "width");
-  const fullHeight = parsedViewBox?.height ?? svgDimension(sourceSvg, "height");
-  const viewBoxX = parsedViewBox?.x ?? 0;
-  const viewBoxY = parsedViewBox?.y ?? 0;
-  if (fullWidth <= 0 || fullHeight <= 0) {
-    return [];
-  }
-
-  return groupLayoutsBySystem(layouts).map((group) => {
-    const top = Math.max(viewBoxY, Math.floor(Math.min(...group.map((layout) => layout.top)) - 8));
-    const bottom = Math.min(viewBoxY + fullHeight, Math.ceil(Math.max(...group.map((layout) => layout.bottom)) + 8));
-    const height = Math.max(1, bottom - top);
-    const clonedSvg = sourceSvg.cloneNode(true) as SVGSVGElement;
-    clonedSvg.setAttribute("width", String(fullWidth));
-    clonedSvg.setAttribute("height", String(height));
-    clonedSvg.setAttribute("viewBox", `${viewBoxX} ${top} ${fullWidth} ${height}`);
-
-    return {
-      height,
-      measureEnd: group[group.length - 1].measure,
-      measureStart: group[0].measure,
-      svgMarkup: clonedSvg.outerHTML,
-      width: fullWidth,
-    };
-  });
-}
-
-function groupLayoutsBySystem(layouts: MeasureLayout[]): MeasureLayout[][] {
-  const groups: MeasureLayout[][] = [];
-  layouts.forEach((layout) => {
-    const index = Math.max(0, Math.floor((layout.measure - 1) / MEASURES_PER_LINE));
-    if (!groups[index]) {
-      groups[index] = [];
+  return pages.flatMap((page, pageIndex) => {
+    const sourceSvg = containers[pageIndex]?.querySelector("svg");
+    if (!sourceSvg) {
+      return [];
     }
-    groups[index].push(layout);
+
+    return [
+      {
+        height: PAGE_HEIGHT_PX,
+        measureEnd: page.measureEnd,
+        measureStart: page.measureStart,
+        svgMarkup: sourceSvg.outerHTML,
+        width: PAGE_WIDTH_PX,
+      },
+    ];
   });
-  return groups.filter((group): group is MeasureLayout[] => Boolean(group?.length));
 }
 
-function svgDimension(svg: SVGSVGElement, attribute: "width" | "height"): number {
-  const raw = Number.parseFloat(svg.getAttribute(attribute) ?? "");
-  if (Number.isFinite(raw) && raw > 0) {
-    return raw;
+function paginateMeasures(
+  measures: Measure[],
+  bpm: number,
+  showLyrics: boolean,
+): { measureWidth: number; measuresPerLine: number; measuresPerPage: number; pages: PageDescriptor[] } {
+  const measuresPerLine = chooseMeasuresPerLine(measures, bpm);
+  const lineHeight = showLyrics ? LINE_HEIGHT_WITH_LYRICS : LINE_HEIGHT_WITHOUT_LYRICS;
+  const innerHeight = PAGE_HEIGHT_PX - PAGE_PADDING_Y * 2;
+  const linesPerPage = Math.max(1, Math.floor(innerHeight / lineHeight));
+  const measuresPerPage = Math.max(1, measuresPerLine * linesPerPage);
+  const minimumMeasureWidth = SLOTS_PER_MEASURE * MIN_SLOT_WIDTH_PX + REGULAR_MEASURE_RESERVE_PX;
+  const innerWidth = PAGE_WIDTH_PX - PAGE_PADDING_X * 2;
+  const measureWidth = Math.max(minimumMeasureWidth, innerWidth / measuresPerLine);
+  const pages: PageDescriptor[] = [];
+
+  for (let startIndex = 0; startIndex < measures.length; startIndex += measuresPerPage) {
+    const endIndex = Math.min(measures.length, startIndex + measuresPerPage);
+    pages.push({
+      measureEnd: endIndex,
+      measureStart: startIndex + 1,
+      measures: measures.slice(startIndex, endIndex),
+    });
   }
 
-  const parsedViewBox = parseSvgViewBox(svg.getAttribute("viewBox"));
-  if (parsedViewBox) {
-    return attribute === "width" ? parsedViewBox.width : parsedViewBox.height;
+  if (pages.length === 0) {
+    pages.push({
+      measureEnd: 1,
+      measureStart: 1,
+      measures: [{ slots: emptySlots() }],
+    });
   }
 
-  return 0;
+  return { measureWidth, measuresPerLine, measuresPerPage, pages };
 }
 
-function parseSvgViewBox(value: string | null): { height: number; width: number; x: number; y: number } | null {
-  if (!value) {
-    return null;
+function chooseMeasuresPerLine(measures: Measure[], bpm: number): number {
+  const innerWidth = PAGE_WIDTH_PX - PAGE_PADDING_X * 2;
+  const strictMinimumMeasureWidth = SLOTS_PER_MEASURE * MIN_SLOT_WIDTH_PX + FIRST_MEASURE_RESERVE_PX;
+  if (innerWidth < strictMinimumMeasureWidth * 2) {
+    return 1;
   }
 
-  const [x, y, width, height] = value
-    .trim()
-    .split(/[\s,]+/)
-    .map((part) => Number.parseFloat(part));
-  if (![x, y, width, height].every((part) => Number.isFinite(part))) {
-    return null;
+  if (measures.length <= 2) {
+    return Math.max(1, Math.min(measures.length, Math.floor(innerWidth / strictMinimumMeasureWidth)));
   }
 
-  return { x, y, width, height };
+  const averageEventDensity =
+    measures.reduce(
+      (total, measure) =>
+        total +
+        measure.slots.reduce((slotTotal, slot) => slotTotal + slot.voice1.length + slot.voice2.length + slot.lyrics.length, 0),
+      0,
+    ) / Math.max(measures.length, 1);
+  const preferredMeasuresPerLine = bpm >= 150 || averageEventDensity >= 18 ? 1 : 1;
+
+  return Math.max(1, Math.min(preferredMeasuresPerLine, Math.floor(innerWidth / strictMinimumMeasureWidth)));
 }
 
 function simplifyVoice(measure: Measure, voice: VoiceNumber): DisplayTick[] {
@@ -469,18 +657,20 @@ function simplifyVoice(measure: Measure, voice: VoiceNumber): DisplayTick[] {
 }
 
 function makeVoiceNote(tick: DisplayTick, voice: VoiceNumber): StaveNote {
-  const renderEvents = renderableEvents(tick.events);
-  const keys = renderEvents.length > 0 ? uniqueKeys(renderEvents) : [voice === 1 ? "g/5" : "f/4"];
-  const hasOnlyXHeads = renderEvents.length > 0 && renderEvents.every((event) => event.notehead === "x");
+  const keys = tick.events.length > 0 ? uniqueKeys(tick.events) : [voice === 1 ? "g/5" : "f/4"];
   const note = new StaveNote({
     clef: "percussion",
     keys,
-    ...(hasOnlyXHeads ? { type: "x" } : {}),
-    duration: tick.hiddenRest || renderEvents.length === 0 ? `${tick.duration}r` : tick.duration,
+    duration: tick.hiddenRest || tick.events.length === 0 ? `${tick.duration}r` : tick.duration,
     stem_direction: voice === 1 ? 1 : -1,
   });
 
   note.setFlagStyle({ fillStyle: "transparent", strokeStyle: "transparent" });
+  keys.forEach((key, index) => {
+    if (tick.events.some((event) => event.staff_key === key && event.notehead === "x")) {
+      note.setKeyStyle(index, { fillStyle: "transparent", strokeStyle: "transparent" });
+    }
+  });
 
   if (tick.events.some((event) => event.articulation === "accent")) {
     note.addModifier(new Articulation("a>").setPosition(3), 0);
@@ -498,6 +688,53 @@ function renderableEvents(events: NotationEvent[]): NotationEvent[] {
   return events.filter((event) => event.notehead === "normal");
 }
 
+function drawCustomXNoteheads(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  notes: StaveNote[],
+  ticks: DisplayTick[],
+) {
+  notes.forEach((note, noteIndex) => {
+    const tick = ticks[noteIndex];
+    if (!tick || tick.hiddenRest) {
+      return;
+    }
+
+    const keys = uniqueKeys(tick.events);
+    const ys = note.getYs();
+    tick.events.forEach((event) => {
+      if (event.notehead !== "x") {
+        return;
+      }
+
+      const keyIndex = keys.indexOf(event.staff_key);
+      const y = ys[keyIndex] ?? ys[0];
+      if (!Number.isFinite(y)) {
+        return;
+      }
+
+      drawXNotehead(context, note.getAbsoluteX(), y);
+    });
+  });
+}
+
+function drawXNotehead(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  centerX: number,
+  centerY: number,
+) {
+  const size = 5.5;
+  context.save();
+  context.setStrokeStyle("#111317");
+  context.setLineWidth(1.6);
+  context.beginPath();
+  context.moveTo(centerX - size, centerY - size);
+  context.lineTo(centerX + size, centerY + size);
+  context.moveTo(centerX + size, centerY - size);
+  context.lineTo(centerX - size, centerY + size);
+  context.stroke();
+  context.restore();
+}
+
 function prepareStraightBeamStems(notes: StaveNote[], ticks: DisplayTick[], voice: VoiceNumber) {
   for (const group of beatGroups(notes, ticks)) {
     if (!shouldDrawBeam(group.ticks)) {
@@ -510,16 +747,16 @@ function prepareStraightBeamStems(notes: StaveNote[], ticks: DisplayTick[], voic
     }
 
     if (voice === 1) {
-      const beamY = Math.min(...visible.map(({ note }) => note.getStemExtents().baseY)) - 34;
+      const beamY = Math.min(...visible.map(({ note }) => note.getStemExtents().baseY)) - 36;
       for (const { note } of visible) {
         const baseY = note.getStemExtents().baseY;
-        note.setStemLength(Math.max(24, baseY - beamY));
+        note.setStemLength(Math.max(28, baseY - beamY));
       }
     } else {
-      const beamY = Math.max(...visible.map(({ note }) => note.getStemExtents().topY)) + 34;
+      const beamY = Math.max(...visible.map(({ note }) => note.getStemExtents().topY)) + 36;
       for (const { note } of visible) {
         const topY = note.getStemExtents().topY;
-        note.setStemLength(Math.max(24, beamY - topY));
+        note.setStemLength(Math.max(28, beamY - topY));
       }
     }
   }
@@ -708,7 +945,7 @@ function slotToX(stave: Stave, slot: number): number {
   return startX + ((slot + 0.5) / SLOTS_PER_MEASURE) * (endX - startX);
 }
 
-function measureLayoutFromStave(stave: Stave, measure: number, showLyrics: boolean): MeasureLayout {
+function measureLayoutFromStave(stave: Stave, measure: number, pageIndex: number, showLyrics: boolean): MeasureLayout {
   const slotZero = slotToX(stave, 0);
   const slotOne = slotToX(stave, 1);
   const slotWidth = Math.max(1, slotOne - slotZero);
@@ -722,6 +959,7 @@ function measureLayoutFromStave(stave: Stave, measure: number, showLyrics: boole
     gridEndX,
     gridStartX,
     measure,
+    pageIndex,
     slotWidth,
     top,
   };


### PR DESCRIPTION
﻿## 변경 내용 요약
- 드럼 악보를 가로 스크롤 대신 페이지 단위로 탐색할 수 있도록 레이아웃을 변경했습니다.
- 현재 재생 중인 페이지에만 오버레이가 표시되도록 동기화 로직을 정리했습니다.
- 하이햇 `x` notehead와 빔 길이를 커스텀 렌더링으로 보정해 기보 가독성을 높였습니다.

## 변경 이유
- 긴 악보를 실제 악보처럼 읽고 넘길 수 있어야 사용성이 좋아집니다.
- 재생 위치와 페이지가 어긋나면 따라 읽기 어렵기 때문에 현재 페이지 기준 오버레이 정렬이 필요했습니다.
- 퍼커션 표기는 음표 머리와 빔 모양이 명확해야 드러머가 빠르게 읽을 수 있습니다.

## 주요 변경 사항
- `DrumSheet.tsx`에서 측정 단위를 페이지로 분할하고 페이지 이동 버튼, 가시 페이지 추적, 페이지별 오버레이/클릭 시킹을 추가했습니다.
- SVG 출력 수집을 페이지 단위로 바꾸고 재생 커서/가사 하이라이트 좌표를 페이지 스케일에 맞춰 계산하도록 수정했습니다.
- `globals.css`에서 악보 뷰를 책 형태의 페이지 스트립 UI로 바꾸고 반응형 페이지 네비게이션 스타일을 추가했습니다.
- 하이햇 `x` notehead를 별도 드로잉으로 렌더링하고 손/발 성부의 빔 길이를 조금 더 안정적으로 보정했습니다.

## 테스트 방법
- `npm --workspace apps/web run lint`
- `npm --workspace apps/web run build`
- `python` 및 `py` 실행 파일이 없어 `harness\beatly_quality_harness.py`는 이 환경에서 실행하지 못했습니다.
