### PR TITLE
[FE] 멀티 악기 악보 뷰 전환 기능 추가

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -15,7 +15,8 @@ from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, UploadF
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
-from app.models import AnalysisJobStatus, AnalysisResult, LyricWord
+from app.models import AnalysisJobStatus, AnalysisResult, AnalysisTrack, LyricWord
+from app.services.bass_analysis import BASS_EXTRACTION_VERSION, analyze_bass_track
 from app.services.audio_preprocess import AudioPreprocessError, prepare_audio_for_analysis
 from app.services.drum_analysis import analyze_drum_track
 from app.services.drum_separation import DrumSeparationError, separate_stems_with_demucs
@@ -290,6 +291,7 @@ def _run_analysis(
         stems.drums,
         stems.vocals,
         settings.separated_dir / upload_path.stem / "prepared",
+        bass_audio=stems.bass,
         include_vocals=needs_whisper_timing,
     )
     logger.info("[%s] audio preprocessing finished in %.1fs", request_id, time.perf_counter() - step_started)
@@ -303,6 +305,17 @@ def _run_analysis(
         request_id,
         time.perf_counter() - step_started,
         len(drum_events),
+    )
+
+    step_started = time.perf_counter()
+    _report_progress(progress, "Extracting bass pitches.")
+    logger.info("[%s] bass analysis started", request_id)
+    bass_spec = analyze_bass_track(prepared_audio.bass, bpm)
+    logger.info(
+        "[%s] bass analysis finished in %.1fs with %d notes",
+        request_id,
+        time.perf_counter() - step_started,
+        len(bass_spec.notes),
     )
 
     if has_provided_lyrics and needs_whisper_alignment:
@@ -403,6 +416,32 @@ def _run_analysis(
         ticks_per_quarter=TICKS_PER_QUARTER,
         midi_ticks=midi_ticks,
         engraved_measures=engraved_measures,
+        bassSpec=bass_spec,
+        bass_spec=bass_spec,
+        BASS_SPEC=bass_spec,
+        tracks=[
+            AnalysisTrack(
+                id="drum",
+                label="Drum",
+                bpm=bpm,
+                instrumentType="DRUM",
+                instrument_type="DRUM",
+                words=words,
+                midi_ticks=midi_ticks,
+                engraved_measures=engraved_measures,
+            ),
+            AnalysisTrack(
+                id="bass",
+                label="Bass",
+                bpm=bpm,
+                instrumentType="BASS",
+                instrument_type="BASS",
+                bassSpec=bass_spec,
+                bass_spec=bass_spec,
+                BASS_SPEC=bass_spec,
+                words=words,
+            ),
+        ],
     )
     _store_cached_analysis(settings.analysis_cache_dir, cache_key, result)
     return result
@@ -492,6 +531,7 @@ def _analysis_cache_key(
     payload = {
         "alignment_mode": alignment_mode,
         "audio_sha256": upload_hash,
+        "bass_extraction_version": BASS_EXTRACTION_VERSION,
         "demucs_device": getattr(settings, "demucs_device", None),
         "demucs_mode": demucs_mode,
         "demucs_model": getattr(settings, "demucs_model", None),

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -6,6 +6,10 @@ from pydantic import BaseModel, Field
 DrumNote = Literal["kick", "snare", "hihat_closed", "hihat_open", "tom", "crash", "ride"]
 NotationVoice = Literal[1, 2]
 Articulation = Literal["accent", "open", "closed", "ghost", "none"]
+InstrumentType = Literal["DRUM", "BASS", "GUITAR", "KEYBOARD"]
+BassRenderMode = Literal["standard", "tab", "both"]
+BassDuration = Literal["w", "h", "q", "8", "16"]
+BassSlideDirection = Literal["up", "down"]
 
 
 class LyricWord(BaseModel):
@@ -81,6 +85,58 @@ class EngravedMeasure(BaseModel):
     lyric_slots: list[LyricSlot] = Field(default_factory=list)
 
 
+class BassSpecNote(BaseModel):
+    id: str | None = None
+    time: float | None = None
+    measure: int | None = None
+    slot: int | None = None
+    duration: BassDuration | None = None
+    duration_slots: int | None = None
+    midi_note: int | None = None
+    staff_key: str | None = None
+    string: Literal[1, 2, 3, 4] | None = None
+    fret: int | Literal["X", "x", "0"] | None = None
+    lyric: str | None = None
+    confidence: float | None = None
+    chord: str | None = None
+    harmony: str | None = None
+    technique: str | None = None
+    techniques: list[str] = Field(default_factory=list)
+    is_dead: bool = False
+    is_staccato: bool = False
+    tie_to_next: bool = False
+    tie_from_previous: bool = False
+    slur_to_next: bool = False
+    slur_from_previous: bool = False
+    slide_direction: BassSlideDirection | None = None
+    slide_out_direction: BassSlideDirection | None = None
+    slide_out_to_nowhere: bool = False
+    prefer_string: Literal[1, 2, 3, 4] | None = None
+    slap_style: bool = False
+    is_pop: bool = False
+    is_pull_off: bool = False
+
+
+class BassSpec(BaseModel):
+    mode: BassRenderMode = "both"
+    notes: list[BassSpecNote] = Field(default_factory=list)
+
+
+class AnalysisTrack(BaseModel):
+    id: str | None = None
+    label: str | None = None
+    name: str | None = None
+    bpm: float | None = None
+    instrumentType: InstrumentType | None = None
+    instrument_type: InstrumentType | None = None
+    bassSpec: BassSpec | None = None
+    bass_spec: BassSpec | None = None
+    BASS_SPEC: BassSpec | None = None
+    words: list[LyricWord] = Field(default_factory=list)
+    midi_ticks: list[MidiTickEvent] = Field(default_factory=list)
+    engraved_measures: list[EngravedMeasure] = Field(default_factory=list)
+
+
 class AnalysisResult(BaseModel):
     bpm: float
     events: list[ScoreEvent]
@@ -88,6 +144,12 @@ class AnalysisResult(BaseModel):
     ticks_per_quarter: int = 480
     midi_ticks: list[MidiTickEvent] = Field(default_factory=list)
     engraved_measures: list[EngravedMeasure] = Field(default_factory=list)
+    instrumentType: InstrumentType | None = None
+    instrument_type: InstrumentType | None = None
+    bassSpec: BassSpec | None = None
+    bass_spec: BassSpec | None = None
+    BASS_SPEC: BassSpec | None = None
+    tracks: list[AnalysisTrack] = Field(default_factory=list)
 
 
 class AnalysisJobStatus(BaseModel):

--- a/apps/api/app/services/audio_preprocess.py
+++ b/apps/api/app/services/audio_preprocess.py
@@ -13,12 +13,14 @@ class AudioPreprocessError(RuntimeError):
 class PreparedAudio:
     drums: Path
     vocals: Path
+    bass: Path | None = None
 
 
 def prepare_audio_for_analysis(
     drums_audio: Path,
     vocals_audio: Path,
     output_dir: Path,
+    bass_audio: Path | None = None,
     include_vocals: bool = True,
 ) -> PreparedAudio:
     """Create lightweight mono WAV files for analysis and transcription.
@@ -30,12 +32,15 @@ def prepare_audio_for_analysis(
     output_dir.mkdir(parents=True, exist_ok=True)
     drums_wav = output_dir / "drums-analysis-11025.wav"
     vocals_wav = output_dir / "vocals-whisper-16000.wav"
+    bass_wav = output_dir / "bass-analysis-22050.wav" if bass_audio else None
     _convert_to_mono_wav(drums_audio, drums_wav, sample_rate=11025)
     if include_vocals:
         _convert_to_mono_wav(vocals_audio, vocals_wav, sample_rate=16000)
     else:
         vocals_wav = vocals_audio
-    return PreparedAudio(drums=drums_wav, vocals=vocals_wav)
+    if bass_audio and bass_wav is not None:
+        _convert_to_mono_wav(bass_audio, bass_wav, sample_rate=22050)
+    return PreparedAudio(drums=drums_wav, vocals=vocals_wav, bass=bass_wav)
 
 
 def _convert_to_mono_wav(input_audio: Path, output_audio: Path, sample_rate: int) -> None:

--- a/apps/api/app/services/bass_analysis.py
+++ b/apps/api/app/services/bass_analysis.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import librosa
+import numpy as np
+import soundfile as sf
+
+from app.models import BassSpec, BassSpecNote
+
+BASS_EXTRACTION_VERSION = "bass-pyin-v3-low-register"
+ANALYSIS_SAMPLE_RATE = 22050
+FRAME_LENGTH = 2048
+HOP_LENGTH = 256
+MIN_BASS_MIDI = 28
+MAX_BASS_MIDI = 67
+PRACTICAL_BASS_UPPER_MIDI = 52
+MIN_RMS_FLOOR = 0.0012
+MIN_VOICED_PROBABILITY = 0.22
+SLOTS_PER_MEASURE = 16
+
+
+@dataclass
+class SlotPitch:
+    midi: int | None
+    confidence: float
+    energy: float
+
+
+def analyze_bass_track(audio_path: Path | None, bpm: float) -> BassSpec:
+    if audio_path is None or not audio_path.exists():
+        return BassSpec(mode="both", notes=[])
+
+    y, sr = _load_analysis_audio(audio_path)
+    if y.size < FRAME_LENGTH or not np.any(np.abs(y) > 1e-6):
+        return BassSpec(mode="both", notes=[])
+
+    try:
+        f0, voiced_flag, voiced_prob = librosa.pyin(
+            y,
+            sr=sr,
+            fmin=librosa.note_to_hz("E1"),
+            fmax=librosa.note_to_hz("G4"),
+            frame_length=FRAME_LENGTH,
+            hop_length=HOP_LENGTH,
+        )
+    except Exception:
+        return BassSpec(mode="both", notes=[])
+
+    rms = librosa.feature.rms(y=y, frame_length=FRAME_LENGTH, hop_length=HOP_LENGTH)[0]
+    frame_count = min(len(rms), len(f0))
+    if frame_count == 0:
+        return BassSpec(mode="both", notes=[])
+
+    f0 = np.asarray(f0[:frame_count], dtype=np.float32)
+    voiced_prob = np.asarray(voiced_prob[:frame_count], dtype=np.float32)
+    voiced_flag = np.asarray(voiced_flag[:frame_count], dtype=bool)
+    rms = np.asarray(rms[:frame_count], dtype=np.float32)
+    frame_times = librosa.frames_to_time(np.arange(frame_count), sr=sr, hop_length=HOP_LENGTH)
+    slot_seconds = 60.0 / max(float(bpm), 1.0) / 4.0
+    total_slots = max(1, int(np.ceil((len(y) / sr) / slot_seconds)))
+    energy_reference = max(float(np.percentile(rms, 80)), MIN_RMS_FLOOR)
+
+    slots: list[SlotPitch] = []
+    previous_midi: int | None = None
+    for slot_index in range(total_slots):
+        slot_start = slot_index * slot_seconds
+        slot_end = slot_start + slot_seconds
+        frame_mask = (frame_times >= slot_start) & (frame_times < slot_end)
+        if slot_index == total_slots - 1:
+            frame_mask = (frame_times >= slot_start) & (frame_times <= slot_end + 1e-6)
+        if not np.any(frame_mask):
+            slots.append(SlotPitch(midi=None, confidence=0.0, energy=0.0))
+            continue
+
+        slot_energy = float(np.median(rms[frame_mask]))
+        if slot_energy < max(MIN_RMS_FLOOR, energy_reference * 0.09):
+            slots.append(SlotPitch(midi=None, confidence=0.0, energy=slot_energy))
+            continue
+
+        voiced_mask = frame_mask & voiced_flag & np.isfinite(f0) & (voiced_prob >= MIN_VOICED_PROBABILITY)
+        if not np.any(voiced_mask):
+            slots.append(SlotPitch(midi=None, confidence=0.0, energy=slot_energy))
+            continue
+
+        raw_midi = float(np.median(librosa.hz_to_midi(f0[voiced_mask])))
+        midi = _normalize_detected_bass_midi(raw_midi, previous_midi)
+        confidence = float(np.clip(np.mean(voiced_prob[voiced_mask]) * min(1.0, slot_energy / energy_reference + 0.1), 0.0, 1.0))
+        if midi is None:
+            slots.append(SlotPitch(midi=None, confidence=0.0, energy=slot_energy))
+            continue
+
+        slots.append(SlotPitch(midi=midi, confidence=confidence, energy=slot_energy))
+        previous_midi = midi
+
+    _smooth_slot_pitches(slots)
+    return BassSpec(mode="both", notes=_slot_pitches_to_notes(slots, slot_seconds))
+
+
+def _load_analysis_audio(audio_path: Path) -> tuple[np.ndarray, int]:
+    audio, sr = sf.read(audio_path, dtype="float32", always_2d=False)
+    if audio.ndim > 1:
+        audio = np.mean(audio, axis=1)
+    if sr != ANALYSIS_SAMPLE_RATE:
+        audio = librosa.resample(audio, orig_sr=sr, target_sr=ANALYSIS_SAMPLE_RATE)
+        sr = ANALYSIS_SAMPLE_RATE
+    return np.asarray(audio, dtype=np.float32), sr
+
+
+def _normalize_detected_bass_midi(raw_midi: float, reference_midi: int | None) -> int | None:
+    if not np.isfinite(raw_midi):
+        return None
+
+    rounded = int(round(raw_midi))
+    candidates: list[int] = []
+    for shift in (-36, -24, -12, 0, 12, 24, 36):
+        candidate = rounded + shift
+        if MIN_BASS_MIDI <= candidate <= MAX_BASS_MIDI:
+            candidates.append(candidate)
+
+    if not candidates:
+        while rounded < MIN_BASS_MIDI:
+            rounded += 12
+        while rounded > MAX_BASS_MIDI:
+            rounded -= 12
+        if MIN_BASS_MIDI <= rounded <= MAX_BASS_MIDI:
+            candidates.append(rounded)
+
+    if not candidates:
+        return None
+
+    if reference_midi is None:
+        selected = min(candidates, key=lambda value: abs(value - 40))
+    else:
+        selected = min(candidates, key=lambda value: (abs(value - reference_midi), abs(value - 40)))
+
+    while selected > PRACTICAL_BASS_UPPER_MIDI and selected - 12 >= MIN_BASS_MIDI:
+        selected -= 12
+    return selected
+
+
+def _smooth_slot_pitches(slots: list[SlotPitch]) -> None:
+    if len(slots) < 3:
+        return
+
+    for index in range(1, len(slots) - 1):
+        previous_slot = slots[index - 1]
+        current_slot = slots[index]
+        next_slot = slots[index + 1]
+
+        if current_slot.midi is None and previous_slot.midi is not None and previous_slot.midi == next_slot.midi:
+            if min(previous_slot.confidence, next_slot.confidence) >= 0.4:
+                current_slot.midi = previous_slot.midi
+                current_slot.confidence = min(previous_slot.confidence, next_slot.confidence) * 0.85
+                continue
+
+        if (
+            current_slot.midi is not None
+            and previous_slot.midi is not None
+            and next_slot.midi is not None
+            and previous_slot.midi == next_slot.midi
+            and previous_slot.midi != current_slot.midi
+        ):
+            if current_slot.confidence < min(previous_slot.confidence, next_slot.confidence):
+                current_slot.midi = previous_slot.midi
+                current_slot.confidence = min(previous_slot.confidence, next_slot.confidence) * 0.9
+
+
+def _slot_pitches_to_notes(slots: list[SlotPitch], slot_seconds: float) -> list[BassSpecNote]:
+    notes: list[BassSpecNote] = []
+    slot_index = 0
+
+    while slot_index < len(slots):
+        slot = slots[slot_index]
+        if slot.midi is None:
+            slot_index += 1
+            continue
+
+        run_start = slot_index
+        run_confidences = [slot.confidence]
+        slot_index += 1
+        while slot_index < len(slots) and slots[slot_index].midi == slot.midi:
+            run_confidences.append(slots[slot_index].confidence)
+            slot_index += 1
+
+        emitted_segments = _emit_segments(run_start, slot_index - run_start)
+        for segment_index, (segment_start, duration_slots) in enumerate(emitted_segments):
+            notes.append(
+                BassSpecNote(
+                    id=f"bass-{segment_start}",
+                    time=round(segment_start * slot_seconds, 3),
+                    measure=segment_start // SLOTS_PER_MEASURE + 1,
+                    slot=segment_start % SLOTS_PER_MEASURE,
+                    duration=_duration_from_slots(duration_slots),
+                    duration_slots=duration_slots,
+                    midi_note=slot.midi,
+                    confidence=round(float(np.mean(run_confidences)), 3),
+                    tie_from_previous=segment_index > 0,
+                    tie_to_next=segment_index < len(emitted_segments) - 1,
+                )
+            )
+
+    return notes
+
+
+def _emit_segments(start_slot: int, total_slots: int) -> list[tuple[int, int]]:
+    segments: list[tuple[int, int]] = []
+    current_slot = start_slot
+    remaining = total_slots
+
+    while remaining > 0:
+        slots_left_in_measure = SLOTS_PER_MEASURE - (current_slot % SLOTS_PER_MEASURE)
+        available = min(remaining, slots_left_in_measure)
+        duration_slots = _largest_supported_duration(available)
+        segments.append((current_slot, duration_slots))
+        current_slot += duration_slots
+        remaining -= duration_slots
+
+    return segments
+
+
+def _largest_supported_duration(available_slots: int) -> int:
+    for duration_slots in (16, 8, 4, 2, 1):
+        if available_slots >= duration_slots:
+            return duration_slots
+    return 1
+
+
+def _duration_from_slots(duration_slots: int) -> str:
+    if duration_slots >= 16:
+        return "w"
+    if duration_slots >= 8:
+        return "h"
+    if duration_slots >= 4:
+        return "q"
+    if duration_slots >= 2:
+        return "8"
+    return "16"

--- a/apps/api/app/services/drum_separation.py
+++ b/apps/api/app/services/drum_separation.py
@@ -14,6 +14,7 @@ class DrumSeparationError(RuntimeError):
 class StemPaths:
     drums: Path
     vocals: Path
+    bass: Path | None = None
 
 
 def separate_stems_with_demucs(
@@ -31,9 +32,11 @@ def separate_stems_with_demucs(
     if use_stub:
         drum_stub = output_dir / f"{input_audio.stem}.drums.wav"
         vocal_stub = output_dir / f"{input_audio.stem}.vocals.wav"
+        bass_stub = output_dir / f"{input_audio.stem}.bass.wav"
         shutil.copyfile(input_audio, drum_stub)
         shutil.copyfile(input_audio, vocal_stub)
-        return StemPaths(drums=drum_stub, vocals=vocal_stub)
+        shutil.copyfile(input_audio, bass_stub)
+        return StemPaths(drums=drum_stub, vocals=vocal_stub, bass=bass_stub)
 
     normalized_mode = mode.lower().strip()
     if normalized_mode in {"none", "off", "skip"}:
@@ -65,12 +68,15 @@ def separate_stems_with_demucs(
     stem_dir = output_dir / model_name / input_audio.stem
     drum_path = stem_dir / ("no_vocals.wav" if normalized_mode == "vocals" else "drums.wav")
     vocal_path = stem_dir / "vocals.wav"
+    bass_path = stem_dir / "bass.wav" if normalized_mode != "vocals" else None
     if not drum_path.exists():
         raise DrumSeparationError(f"Demucs completed, but analysis stem was not found at {drum_path}")
     if not vocal_path.exists():
         raise DrumSeparationError(f"Demucs completed, but vocal stem was not found at {vocal_path}")
+    if bass_path is not None and not bass_path.exists():
+        bass_path = None
 
-    return StemPaths(drums=drum_path, vocals=vocal_path)
+    return StemPaths(drums=drum_path, vocals=vocal_path, bass=bass_path)
 
 
 def separate_drums_with_demucs(input_audio: Path, output_dir: Path, use_stub: bool = False) -> Path:

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -46,6 +46,37 @@ input {
   margin-bottom: 24px;
 }
 
+.instrument-selector {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.instrument-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink);
+  background: #fff;
+  cursor: pointer;
+}
+
+.instrument-button.active {
+  border-color: var(--accent);
+  color: #fff;
+  background: var(--accent);
+}
+
+.instrument-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
 .title {
   margin: 0 0 8px;
   font-size: 34px;
@@ -150,6 +181,12 @@ input {
 
 .status {
   color: var(--accent-strong);
+}
+
+.track-status {
+  margin: -2px 0 6px;
+  color: var(--muted);
+  line-height: 1.5;
 }
 
 .meta {
@@ -459,13 +496,19 @@ input {
     display: block;
   }
 
+  .instrument-selector {
+    justify-content: flex-start;
+    margin-top: 16px;
+  }
+
   .title {
     font-size: 28px;
   }
 
   .file-input,
   .text-input,
-  .button {
+  .button,
+  .instrument-button {
     width: 100%;
   }
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,25 +1,28 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { DrumSheet, type DrumSheetHandle, type PrintableScoreSystem } from "@/components/DrumSheet";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ScoreSheet, type ScoreSheetHandle } from "@/components/ScoreSheet";
+import type { PrintableScoreSystem } from "@/components/DrumSheet";
 import {
   SynchronizedScorePlayer,
   type PlaybackSource,
   type SynchronizedScorePlayerHandle,
 } from "@/components/SynchronizedScorePlayer";
 import { analyzeAudio, analyzeYouTube } from "@/lib/api";
-import type { AnalysisJobStatus, AnalysisResult } from "@/lib/types";
+import { INSTRUMENT_OPTIONS, instrumentLabel, resolveInstrumentView, resolvedViewMeasureCount, resolvedViewNoteCount } from "@/lib/scoreTracks";
+import type { AnalysisJobStatus, AnalysisResult, InstrumentType } from "@/lib/types";
 
 type SourceType = "upload" | "youtube";
 
 export default function Home() {
   const audioObjectUrlRef = useRef<string | null>(null);
   const playerRef = useRef<SynchronizedScorePlayerHandle | null>(null);
-  const sheetRef = useRef<DrumSheetHandle | null>(null);
+  const sheetRef = useRef<ScoreSheetHandle | null>(null);
   const [sourceType, setSourceType] = useState<SourceType>("upload");
   const [file, setFile] = useState<File | null>(null);
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [score, setScore] = useState<AnalysisResult | null>(null);
+  const [selectedInstrument, setSelectedInstrument] = useState<InstrumentType>("DRUM");
   const [playbackSource, setPlaybackSource] = useState<PlaybackSource | null>(null);
   const [audioCurrentTime, setAudioCurrentTime] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -30,6 +33,10 @@ export default function Home() {
   const [showLyrics, setShowLyrics] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusText, setStatusText] = useState<string | null>(null);
+  const resolvedInstrumentView = useMemo(
+    () => (score ? resolveInstrumentView(score, selectedInstrument) : null),
+    [score, selectedInstrument],
+  );
 
   useEffect(() => {
     return () => {
@@ -190,10 +197,26 @@ export default function Home() {
       <div className="shell">
         <div className="topbar">
           <div>
-            <h1 className="title">Beatly Drum Sheet</h1>
+            <h1 className="title">Beatly Multi-Instrument Score</h1>
             <p className="subtitle">
-              Upload audio or paste a YouTube link to generate a synchronized drum score.
+              Upload audio or paste a YouTube link to generate a synchronized score and switch between drum, bass, guitar,
+              and keyboard views.
             </p>
+          </div>
+          <div className="instrument-selector" aria-label="Instrument selector">
+            {INSTRUMENT_OPTIONS.map((option) => (
+              <button
+                className={selectedInstrument === option.instrument ? "instrument-button active" : "instrument-button"}
+                key={option.instrument}
+                onClick={() => setSelectedInstrument(option.instrument)}
+                type="button"
+              >
+                <span aria-hidden="true" className="instrument-icon">
+                  {option.icon}
+                </span>
+                <span>{option.label}</span>
+              </button>
+            ))}
           </div>
         </div>
 
@@ -273,9 +296,20 @@ export default function Home() {
           <>
             <div className="meta">
               <span className="pill">BPM {Math.round(score.bpm)}</span>
-              <span className="pill">Drum events {score.events.length}</span>
+              <span className="pill">Track {resolvedInstrumentView?.label ?? instrumentLabel(selectedInstrument)}</span>
+              <span className="pill">Measures {resolvedInstrumentView ? resolvedViewMeasureCount(resolvedInstrumentView) : 0}</span>
+              <span className="pill">Notes {resolvedInstrumentView ? resolvedViewNoteCount(resolvedInstrumentView) : 0}</span>
               <span className="pill">Words {score.words.length}</span>
+              {resolvedInstrumentView && resolvedInstrumentView.source === "derived" ? (
+                <span className="pill">Derived Preview</span>
+              ) : null}
             </div>
+            {resolvedInstrumentView && resolvedInstrumentView.source === "derived" ? (
+              <div className="track-status">
+                {resolvedInstrumentView.label} is currently rendered from the drum timing map because the API response does not
+                include an explicit {resolvedInstrumentView.label.toLowerCase()} track yet.
+              </div>
+            ) : null}
             {playbackSource ? (
               <SynchronizedScorePlayer
                 ref={playerRef}
@@ -288,12 +322,14 @@ export default function Home() {
                 source={playbackSource}
               />
             ) : null}
-            <DrumSheet
+            <ScoreSheet
               audioCurrentTime={audioCurrentTime}
               followPlayback={followPlayback}
+              instrument={selectedInstrument}
               isPlaying={isPlaybackActive}
               onSeek={handleScoreSeek}
               onFollowPlaybackChange={setFollowPlayback}
+              key={`score-${selectedInstrument}`}
               ref={sheetRef}
               score={score}
               showLyrics={showLyrics}

--- a/apps/web/components/BassSheet.tsx
+++ b/apps/web/components/BassSheet.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Annotation,
   Articulation,
   Beam,
   Curve,
@@ -62,6 +61,7 @@ type RenderedBassNote = {
   centerX: number;
   note: BassRenderNote;
   standardNote: StaveNote | null;
+  systemKey: string;
   tabStave: TabStave;
 };
 
@@ -70,7 +70,7 @@ const PAGE_PADDING_X = 24;
 const PAGE_PADDING_Y = 34;
 const PAGE_WIDTH_PX = 794;
 const SLOTS_PER_MEASURE = 16;
-const MIN_SLOT_WIDTH_PX = 40;
+const MEASURES_PER_LINE = 4;
 const FIRST_MEASURE_RESERVE_PX = 76;
 const REGULAR_MEASURE_RESERVE_PX = 24;
 const LYRIC_FONT_SIZE = 12;
@@ -177,10 +177,14 @@ export const BassSheet = forwardRef<DrumSheetHandle, Props>(function BassSheet(
 
         page.measures.forEach((measure, localIndex) => {
           const globalIndex = page.measureStart - 1 + localIndex;
-          const x = PAGE_PADDING_X;
-          const y = PAGE_PADDING_Y + localIndex * lineHeight;
+          const measureInLine = localIndex % MEASURES_PER_LINE;
+          const lineIndex = Math.floor(localIndex / MEASURES_PER_LINE);
+          const x = PAGE_PADDING_X + measureInLine * measureWidth;
+          const y = PAGE_PADDING_Y + lineIndex * lineHeight;
           const staveWidth = measureWidth;
           const displayTicks = buildBassDisplayTicks(measure);
+          const isLineStart = measureInLine === 0;
+          const systemKey = `${pageIndex}:${lineIndex}`;
 
           drawMeasureNumber(context, globalIndex + 1, x, y);
 
@@ -188,14 +192,14 @@ export const BassSheet = forwardRef<DrumSheetHandle, Props>(function BassSheet(
           const tabStave = new TabStave(x, y + TAB_GAP_PX, staveWidth, { num_lines: 4, spacing_between_lines_px: 15 });
 
           if (track.mode !== "tab") {
-            if (localIndex === 0) {
+            if (isLineStart) {
               standardStave.addClef("bass").addTimeSignature("4/4");
             }
             standardStave.setContext(context).draw();
           }
 
           if (track.mode !== "standard") {
-            if (localIndex === 0) {
+            if (isLineStart) {
               tabStave.addClef("tab").addTimeSignature("4/4");
             }
             tabStave.setContext(context).draw();
@@ -210,13 +214,13 @@ export const BassSheet = forwardRef<DrumSheetHandle, Props>(function BassSheet(
             const voice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
             voice.addTickables(notes);
 
-            const formatterWidth = staveWidth - (localIndex === 0 ? FIRST_MEASURE_RESERVE_PX : REGULAR_MEASURE_RESERVE_PX);
+            const formatterWidth = staveWidth - (isLineStart ? FIRST_MEASURE_RESERVE_PX : REGULAR_MEASURE_RESERVE_PX);
             new Formatter().joinVoices([voice]).format([voice], formatterWidth);
             voice.draw(context, standardStave);
             Beam.generateBeams(notes).forEach((beam) => beam.setContext(context).draw());
 
             drawTabNumbers(context, displayTicks, notes, tabStave, track.mode);
-            renderedNotes.push(...collectRenderedNotes(displayTicks, notes, tabStave));
+            renderedNotes.push(...collectRenderedNotes(displayTicks, notes, tabStave, systemKey));
 
             if (showLyrics) {
               drawLyricLane(context, lyricsHostStave(track.mode, standardStave, tabStave), measure);
@@ -227,7 +231,7 @@ export const BassSheet = forwardRef<DrumSheetHandle, Props>(function BassSheet(
           }
 
           drawTabNumbers(context, displayTicks, [], tabStave, track.mode);
-          renderedNotes.push(...collectRenderedNotes(displayTicks, [], tabStave));
+          renderedNotes.push(...collectRenderedNotes(displayTicks, [], tabStave, systemKey));
           if (showLyrics) {
             drawLyricLane(context, tabStave, measure);
           }
@@ -686,13 +690,11 @@ function paginateMeasures(
   measures: BassMeasure[],
   lineHeight: number,
 ): { measureWidth: number; measuresPerPage: number; pages: PageDescriptor[] } {
-  const measuresPerLine = 1;
   const innerHeight = PAGE_HEIGHT_PX - PAGE_PADDING_Y * 2;
   const linesPerPage = Math.max(1, Math.floor(innerHeight / lineHeight));
-  const measuresPerPage = Math.max(1, measuresPerLine * linesPerPage);
-  const minimumMeasureWidth = SLOTS_PER_MEASURE * MIN_SLOT_WIDTH_PX + REGULAR_MEASURE_RESERVE_PX;
+  const measuresPerPage = Math.max(1, MEASURES_PER_LINE * linesPerPage);
   const innerWidth = PAGE_WIDTH_PX - PAGE_PADDING_X * 2;
-  const measureWidth = Math.max(minimumMeasureWidth, innerWidth / measuresPerLine);
+  const measureWidth = innerWidth / MEASURES_PER_LINE;
   const pages: PageDescriptor[] = [];
 
   for (let startIndex = 0; startIndex < measures.length; startIndex += measuresPerPage) {
@@ -730,7 +732,7 @@ function buildBassDisplayTicks(measure: BassMeasure): BassDisplayTick[] {
         measure.notes.find((entry) => entry.slot > slot)?.slot ?? SLOTS_PER_MEASURE;
       const durationSlots = Math.max(1, Math.min(note.durationSlots, nextNoteSlot - slot, SLOTS_PER_MEASURE - slot));
       ticks.push({
-        duration: note.duration,
+        duration: durationFromSlots(durationSlots),
         durationSlots,
         note,
         slot,
@@ -818,19 +820,6 @@ function makeBassStandardNote(tick: BassDisplayTick): StaveNote {
       0,
     );
   }
-
-  if (tick.note.techniques.includes("HAMMER_ON")) {
-    note.addModifier(
-      new Annotation("H").setJustification("center").setVerticalJustification("top").setFont("Arial", 12, "bold"),
-      0,
-    );
-  } else if (tick.note.techniques.includes("PULL_OFF")) {
-    note.addModifier(
-      new Annotation("P").setJustification("center").setVerticalJustification("top").setFont("Arial", 12, "bold"),
-      0,
-    );
-  }
-
   return note;
 }
 
@@ -884,6 +873,7 @@ function collectRenderedNotes(
   ticks: BassDisplayTick[],
   standardNotes: StaveNote[],
   tabStave: TabStave,
+  systemKey: string,
 ): RenderedBassNote[] {
   return ticks.flatMap((tick, index) => {
     if (!tick.note) {
@@ -896,6 +886,7 @@ function collectRenderedNotes(
         centerX: standardNote ? noteCenterX(standardNote) : slotToX(tabStave, tick.slot),
         note: tick.note,
         standardNote,
+        systemKey,
         tabStave,
       },
     ];
@@ -908,53 +899,92 @@ function drawTechniqueConnections(
 ) {
   for (let index = 0; index < renderedNotes.length; index += 1) {
     const current = renderedNotes[index];
-    const next = renderedNotes[index + 1];
-    if (!current || !next) {
+    const next = renderedNotes[index + 1] ?? null;
+    if (!current) {
       continue;
     }
+    const connectableNext = next && canConnectRenderedNotes(current, next) ? next : null;
 
-    if (current.note.tieToNext) {
-      if (current.standardNote && next.standardNote) {
-        new StaveTie({
-          first_indices: [0],
-          first_note: current.standardNote,
-          last_indices: [0],
-          last_note: next.standardNote,
-        })
-          .setContext(context)
-          .draw();
-      } else {
-        drawTabArc(context, current, next);
-      }
+    if (current.note.tieToNext && connectableNext) {
+      drawTieConnection(context, current, connectableNext);
     }
 
-    if (current.note.techniques.includes("HAMMER_ON") || current.note.techniques.includes("PULL_OFF")) {
-      if (current.standardNote && next.standardNote) {
-        new Curve(current.standardNote, next.standardNote, {
-          cps: [
-            { x: 0, y: 8 },
-            { x: 0, y: 8 },
-          ],
-          position: "nearHead",
-          position_end: "nearHead",
-          y_shift: 6,
-        })
-          .setContext(context)
-          .draw();
-      } else {
-        drawTabArc(
-          context,
-          current,
-          next,
-          current.note.techniques.includes("HAMMER_ON") ? "H" : "P",
-        );
-      }
+    if ((current.note.techniques.includes("HAMMER_ON") || current.note.techniques.includes("PULL_OFF")) && connectableNext) {
+      drawSlurConnection(context, current, connectableNext, current.note.techniques.includes("HAMMER_ON") ? "H" : "P");
+    } else if (current.note.slurToNext && connectableNext) {
+      drawSlurConnection(context, current, connectableNext);
     }
 
     if (current.note.techniques.includes("SLIDE")) {
-      drawSlideLine(context, current, next);
+      if (connectableNext) {
+        drawSlideLine(context, current, connectableNext);
+      } else {
+        drawSlideOutTail(context, current, current.note.slideOutDirection ?? resolveRenderedSlideDirection(current.note));
+      }
     }
   }
+}
+
+function canConnectRenderedNotes(current: RenderedBassNote, next: RenderedBassNote): boolean {
+  if (current.systemKey !== next.systemKey) {
+    return false;
+  }
+
+  return next.note.measure === current.note.measure || next.note.measure === current.note.measure + 1;
+}
+
+function drawTieConnection(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  current: RenderedBassNote,
+  next: RenderedBassNote,
+) {
+  if (current.standardNote && next.standardNote) {
+    new StaveTie({
+      first_indices: [0],
+      first_note: current.standardNote,
+      last_indices: [0],
+      last_note: next.standardNote,
+    })
+      .setContext(context)
+      .draw();
+    return;
+  }
+
+  drawTabArc(context, current, next);
+}
+
+function drawSlurConnection(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  current: RenderedBassNote,
+  next: RenderedBassNote,
+  label?: "H" | "P",
+) {
+  if (current.standardNote && next.standardNote) {
+    new Curve(current.standardNote, next.standardNote, {
+      cps: [
+        { x: 0, y: 8 },
+        { x: 0, y: 8 },
+      ],
+      position: "nearHead",
+      position_end: "nearHead",
+      y_shift: 6,
+    })
+      .setContext(context)
+      .draw();
+
+    if (label) {
+      const midX = (noteCenterX(current.standardNote) + noteCenterX(next.standardNote)) / 2;
+      const labelY = Math.min(current.standardNote.getYs()[0], next.standardNote.getYs()[0]) - 18;
+      context.save();
+      context.setFont("Arial", 11);
+      context.setFillStyle("#111317");
+      context.fillText(label, midX - 4, labelY);
+      context.restore();
+    }
+    return;
+  }
+
+  drawTabArc(context, current, next, label);
 }
 
 function drawSlideLine(
@@ -962,14 +992,37 @@ function drawSlideLine(
   current: RenderedBassNote,
   next: RenderedBassNote,
 ) {
-  const y1 = current.tabStave.getYForLine(current.note.string - 1);
-  const y2 = next.tabStave.getYForLine(next.note.string - 1);
+  const direction = resolveRenderedSlideDirection(current.note, next.note);
+  const startX = current.centerX + tabLabelHalfWidth(current.note) + 4;
+  const endX = Math.max(startX + 12, next.centerX - tabLabelHalfWidth(next.note) - 4);
+  const startY = tabLineY(current) + (direction === "up" ? 5 : -5);
+  const endY = tabLineY(next) + (direction === "up" ? -5 : 5);
   context.save();
   context.setStrokeStyle("#111317");
   context.setLineWidth(1.6);
   context.beginPath();
-  context.moveTo(current.centerX + 8, y1 - 4);
-  context.lineTo(next.centerX - 8, y2 + 4);
+  context.moveTo(startX, startY);
+  context.lineTo(endX, endY);
+  context.stroke();
+  context.restore();
+}
+
+function drawSlideOutTail(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  current: RenderedBassNote,
+  direction: "up" | "down",
+) {
+  const startX = current.centerX + tabLabelHalfWidth(current.note) + 4;
+  const startY = tabLineY(current) + (direction === "up" ? 4 : -4);
+  const endX = startX + 20;
+  const endY = startY + (direction === "up" ? -12 : 12);
+
+  context.save();
+  context.setStrokeStyle("#111317");
+  context.setLineWidth(1.6);
+  context.beginPath();
+  context.moveTo(startX, startY);
+  context.lineTo(endX, endY);
   context.stroke();
   context.restore();
 }
@@ -1004,12 +1057,48 @@ function noteCenterX(note: StaveNote): number {
   return (note.getTieLeftX() + note.getTieRightX()) / 2;
 }
 
+function tabLineY(renderedNote: RenderedBassNote): number {
+  return renderedNote.tabStave.getYForLine(renderedNote.note.string - 1);
+}
+
+function tabLabelHalfWidth(note: BassRenderNote): number {
+  const label = note.fret === "X" ? "X" : String(note.fret);
+  return Math.max(12, label.length * 9) / 2;
+}
+
+function resolveRenderedSlideDirection(
+  current: BassRenderNote,
+  next?: BassRenderNote | null,
+): "up" | "down" {
+  if (current.slideDirection) {
+    return current.slideDirection;
+  }
+
+  if (next) {
+    if (typeof current.fret === "number" && typeof next.fret === "number" && next.fret !== current.fret) {
+      return next.fret > current.fret ? "up" : "down";
+    }
+    if (current.actualMidi !== null && next.actualMidi !== null && next.actualMidi !== current.actualMidi) {
+      return next.actualMidi > current.actualMidi ? "up" : "down";
+    }
+    if (next.string !== current.string) {
+      return next.string < current.string ? "up" : "down";
+    }
+  }
+
+  if (current.slideOutDirection) {
+    return current.slideOutDirection;
+  }
+
+  return typeof current.fret === "number" && current.fret > 12 ? "down" : "up";
+}
+
 function lyricsHostStave(mode: BassRenderTrack["mode"], standardStave: Stave, tabStave: TabStave): Stave {
   return mode === "tab" ? tabStave : mode === "both" ? tabStave : standardStave;
 }
 
 function stemDirectionForKey(key: string): number {
-  return lineForKey(key) < 2 ? 1 : -1;
+  return lineForKey(key) < 0 ? 1 : -1;
 }
 
 function lineForKey(key: string): number {

--- a/apps/web/components/BassSheet.tsx
+++ b/apps/web/components/BassSheet.tsx
@@ -212,12 +212,16 @@ export const BassSheet = forwardRef<DrumSheetHandle, Props>(function BassSheet(
           if (track.mode !== "tab") {
             const notes = displayTicks.map((tick) => makeBassStandardNote(tick));
             const voice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
+            const beams = Beam.generateBeams(notes, {
+              groups: Beam.getDefaultBeamGroups("4/4"),
+              maintain_stem_directions: true,
+            });
             voice.addTickables(notes);
 
             const formatterWidth = staveWidth - (isLineStart ? FIRST_MEASURE_RESERVE_PX : REGULAR_MEASURE_RESERVE_PX);
             new Formatter().joinVoices([voice]).format([voice], formatterWidth);
             voice.draw(context, standardStave);
-            Beam.generateBeams(notes).forEach((beam) => beam.setContext(context).draw());
+            beams.forEach((beam) => beam.setContext(context).draw());
 
             drawTabNumbers(context, displayTicks, notes, tabStave, track.mode);
             renderedNotes.push(...collectRenderedNotes(displayTicks, notes, tabStave, systemKey));

--- a/apps/web/components/BassSheet.tsx
+++ b/apps/web/components/BassSheet.tsx
@@ -1,0 +1,1179 @@
+"use client";
+
+import {
+  Annotation,
+  Articulation,
+  Beam,
+  Curve,
+  Formatter,
+  Modifier,
+  Renderer,
+  Stave,
+  StaveConnector,
+  StaveNote,
+  StaveTie,
+  TabStave,
+  Voice,
+} from "vexflow";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import type { DrumSheetHandle, PrintableScoreSystem } from "@/components/DrumSheet";
+import type { BassMeasure, BassRenderNote, BassRenderTrack, BassSlot } from "@/lib/scoreTracks";
+
+type Props = {
+  audioCurrentTime?: number;
+  followPlayback?: boolean;
+  isPlaying?: boolean;
+  onFollowPlaybackChange?: (enabled: boolean) => void;
+  onSeek?: (time: number) => void;
+  showLyrics?: boolean;
+  track: BassRenderTrack;
+};
+
+type BassDisplayTick = {
+  duration: "w" | "h" | "q" | "8" | "16";
+  durationSlots: number;
+  note: BassRenderNote | null;
+  slot: number;
+};
+
+type MeasureLayout = {
+  bottom: number;
+  gridEndX: number;
+  gridStartX: number;
+  measure: number;
+  pageIndex: number;
+  slotWidth: number;
+  top: number;
+};
+
+type PageDescriptor = {
+  measureEnd: number;
+  measureStart: number;
+  measures: BassMeasure[];
+};
+
+type PlaybackPosition = {
+  measure: number;
+  slot: number;
+  slotProgress: number;
+};
+
+type RenderedBassNote = {
+  centerX: number;
+  note: BassRenderNote;
+  standardNote: StaveNote | null;
+  tabStave: TabStave;
+};
+
+const PAGE_HEIGHT_PX = 1123;
+const PAGE_PADDING_X = 24;
+const PAGE_PADDING_Y = 34;
+const PAGE_WIDTH_PX = 794;
+const SLOTS_PER_MEASURE = 16;
+const MIN_SLOT_WIDTH_PX = 40;
+const FIRST_MEASURE_RESERVE_PX = 76;
+const REGULAR_MEASURE_RESERVE_PX = 24;
+const LYRIC_FONT_SIZE = 12;
+const LYRIC_HORIZONTAL_PADDING_PX = 5;
+const AUTO_SCROLL_GUARD_MS = 1000;
+const TAB_GAP_PX = 94;
+const LINE_HEIGHT_STANDARD = 168;
+const LINE_HEIGHT_STANDARD_LYRICS = 204;
+const LINE_HEIGHT_TAB = 156;
+const LINE_HEIGHT_TAB_LYRICS = 194;
+const LINE_HEIGHT_BOTH = 270;
+const LINE_HEIGHT_BOTH_LYRICS = 306;
+const TAB_TEXT_FONT_SIZE = 14;
+
+export const BassSheet = forwardRef<DrumSheetHandle, Props>(function BassSheet(
+  { audioCurrentTime = 0, followPlayback = true, isPlaying = false, onFollowPlaybackChange, onSeek, showLyrics = true, track }: Props,
+  ref,
+) {
+  const boardRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const cursorRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const followTargetRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const lyricHighlightRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const measureHighlightRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const overlayLayerRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const pageRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const slotHighlightRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const svgLayerRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const autoScrollGuardUntilRef = useRef(0);
+  const followPlaybackRef = useRef(followPlayback);
+  const isPlayingRef = useRef(isPlaying);
+  const forceCenterNextAlignRef = useRef(false);
+  const lastFollowTargetKeyRef = useRef<string | null>(null);
+  const previousFollowPlaybackRef = useRef(followPlayback);
+  const [measureLayouts, setMeasureLayouts] = useState<MeasureLayout[]>([]);
+  const [pageTranslateX, setPageTranslateX] = useState(0);
+  const [renderError, setRenderError] = useState<string | null>(null);
+  const [visiblePageIndex, setVisiblePageIndex] = useState(0);
+
+  const measures = track.measures;
+  const lineHeight = resolveLineHeight(track.mode, showLyrics);
+  const pagination = useMemo(() => paginateMeasures(measures, lineHeight), [lineHeight, measures]);
+  const pages = pagination.pages;
+  const measuresPerPage = pagination.measuresPerPage;
+  const measureWidth = pagination.measureWidth;
+  const playbackPosition = useMemo(
+    () => timeToPlaybackPosition(audioCurrentTime, track.bpm, measures.length),
+    [audioCurrentTime, measures.length, track.bpm],
+  );
+  const activeLayout = measureLayouts[playbackPosition.measure - 1] ?? null;
+  const targetPageIndex = useMemo(
+    () =>
+      pages.length > 0
+        ? clamp(Math.floor(Math.max(0, playbackPosition.measure - 1) / Math.max(1, measuresPerPage)), 0, pages.length - 1)
+        : 0,
+    [measuresPerPage, pages.length, playbackPosition.measure],
+  );
+
+  useEffect(() => {
+    followPlaybackRef.current = followPlayback;
+  }, [followPlayback]);
+
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  }, [isPlaying]);
+
+  const disableFollowPlayback = useCallback(
+    (ignoreGuard: boolean) => {
+      if (!followPlaybackRef.current || !isPlayingRef.current) {
+        return;
+      }
+      if (!ignoreGuard && performance.now() <= autoScrollGuardUntilRef.current) {
+        return;
+      }
+      onFollowPlaybackChange?.(false);
+    },
+    [onFollowPlaybackChange],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getPrintableSystems: () => collectPrintableSystems(svgLayerRefs.current, pages),
+    }),
+    [pages],
+  );
+
+  useEffect(() => {
+    const nextLayouts: MeasureLayout[] = [];
+
+    try {
+      pages.forEach((page, pageIndex) => {
+        const container = svgLayerRefs.current[pageIndex];
+        if (!container) {
+          return;
+        }
+
+        container.innerHTML = "";
+        const renderer = new Renderer(container, Renderer.Backends.SVG);
+        renderer.resize(PAGE_WIDTH_PX, PAGE_HEIGHT_PX);
+        const context = renderer.getContext();
+        context.setFont("Arial, Malgun Gothic, sans-serif", 12);
+        const renderedNotes: RenderedBassNote[] = [];
+
+        page.measures.forEach((measure, localIndex) => {
+          const globalIndex = page.measureStart - 1 + localIndex;
+          const x = PAGE_PADDING_X;
+          const y = PAGE_PADDING_Y + localIndex * lineHeight;
+          const staveWidth = measureWidth;
+          const displayTicks = buildBassDisplayTicks(measure);
+
+          drawMeasureNumber(context, globalIndex + 1, x, y);
+
+          const standardStave = new Stave(x, y, staveWidth);
+          const tabStave = new TabStave(x, y + TAB_GAP_PX, staveWidth, { num_lines: 4, spacing_between_lines_px: 15 });
+
+          if (track.mode !== "tab") {
+            if (localIndex === 0) {
+              standardStave.addClef("bass").addTimeSignature("4/4");
+            }
+            standardStave.setContext(context).draw();
+          }
+
+          if (track.mode !== "standard") {
+            if (localIndex === 0) {
+              tabStave.addClef("tab").addTimeSignature("4/4");
+            }
+            tabStave.setContext(context).draw();
+          }
+
+          if (track.mode === "both") {
+            new StaveConnector(standardStave, tabStave).setType(StaveConnector.type.SINGLE_LEFT).setContext(context).draw();
+          }
+
+          if (track.mode !== "tab") {
+            const notes = displayTicks.map((tick) => makeBassStandardNote(tick));
+            const voice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
+            voice.addTickables(notes);
+
+            const formatterWidth = staveWidth - (localIndex === 0 ? FIRST_MEASURE_RESERVE_PX : REGULAR_MEASURE_RESERVE_PX);
+            new Formatter().joinVoices([voice]).format([voice], formatterWidth);
+            voice.draw(context, standardStave);
+            Beam.generateBeams(notes).forEach((beam) => beam.setContext(context).draw());
+
+            drawTabNumbers(context, displayTicks, notes, tabStave, track.mode);
+            renderedNotes.push(...collectRenderedNotes(displayTicks, notes, tabStave));
+
+            if (showLyrics) {
+              drawLyricLane(context, lyricsHostStave(track.mode, standardStave, tabStave), measure);
+            }
+
+            nextLayouts[globalIndex] = measureLayoutFromStaves(track.mode, standardStave, tabStave, globalIndex + 1, pageIndex, showLyrics);
+            return;
+          }
+
+          drawTabNumbers(context, displayTicks, [], tabStave, track.mode);
+          renderedNotes.push(...collectRenderedNotes(displayTicks, [], tabStave));
+          if (showLyrics) {
+            drawLyricLane(context, tabStave, measure);
+          }
+          nextLayouts[globalIndex] = measureLayoutFromStaves(track.mode, standardStave, tabStave, globalIndex + 1, pageIndex, showLyrics);
+        });
+
+        if (renderedNotes.length > 0) {
+          drawTechniqueConnections(context, renderedNotes);
+        }
+      });
+
+      setRenderError(null);
+      setMeasureLayouts(nextLayouts);
+    } catch (error) {
+      console.error("BassSheet render failed", error);
+      svgLayerRefs.current.forEach((container) => {
+        if (container) {
+          container.innerHTML = "";
+        }
+      });
+      setMeasureLayouts([]);
+      setRenderError(error instanceof Error ? error.message : "Bass score rendering failed.");
+    }
+  }, [lineHeight, measureWidth, pages, showLyrics, track.mode]);
+
+  useEffect(() => {
+    if (renderError) {
+      return;
+    }
+
+    let frame = 0;
+    frame = requestAnimationFrame(() => {
+      const activePageIndex = activeLayout?.pageIndex ?? -1;
+
+      overlayLayerRefs.current.forEach((overlayLayer, pageIndex) => {
+        if (overlayLayer) {
+          overlayLayer.style.opacity = pageIndex === activePageIndex ? "1" : "0";
+        }
+      });
+
+      const followTarget = activePageIndex >= 0 ? followTargetRefs.current[activePageIndex] : null;
+      const measureHighlight = activePageIndex >= 0 ? measureHighlightRefs.current[activePageIndex] : null;
+      const overlayLayer = activePageIndex >= 0 ? overlayLayerRefs.current[activePageIndex] : null;
+      const slotHighlight = activePageIndex >= 0 ? slotHighlightRefs.current[activePageIndex] : null;
+      const cursor = activePageIndex >= 0 ? cursorRefs.current[activePageIndex] : null;
+      const lyricHighlight = activePageIndex >= 0 ? lyricHighlightRefs.current[activePageIndex] : null;
+      const board = activePageIndex >= 0 ? boardRefs.current[activePageIndex] : null;
+      const layout = measureLayouts[playbackPosition.measure - 1] ?? null;
+      const measure = measures[playbackPosition.measure - 1] ?? null;
+      const slot = measure?.slots[playbackPosition.slot] ?? null;
+      const lyric = showLyrics
+        ? (slot?.lyrics[0]?.lyric?.trim().normalize("NFC") ?? slot?.lyric?.trim().normalize("NFC") ?? null)
+        : null;
+
+      if (!followTarget || !measureHighlight || !overlayLayer || !slotHighlight || !cursor || !lyricHighlight || !board) {
+        return;
+      }
+
+      if (!layout) {
+        overlayLayer.style.opacity = "0";
+        measureHighlight.style.opacity = "0";
+        lyricHighlight.style.opacity = "0";
+        return;
+      }
+
+      const cursorX =
+        layout.gridStartX + (playbackPosition.slotProgress / SLOTS_PER_MEASURE) * (layout.gridEndX - layout.gridStartX);
+      const activeSlotLeft = layout.gridStartX + playbackPosition.slot * layout.slotWidth;
+      const activeMeasureWidth = layout.gridEndX - layout.gridStartX;
+      const activeSlotHeight = layout.bottom - layout.top;
+      const activeMeasureCenterY = (layout.top + layout.bottom) / 2;
+      const boardRect = board.getBoundingClientRect();
+      const scaleX = boardRect.width / PAGE_WIDTH_PX;
+      const scaleY = boardRect.height / PAGE_HEIGHT_PX;
+
+      overlayLayer.style.opacity = "1";
+      measureHighlight.style.opacity = "1";
+      measureHighlight.style.height = `${activeSlotHeight * scaleY}px`;
+      measureHighlight.style.width = `${activeMeasureWidth * scaleX}px`;
+      measureHighlight.style.transform = `translate(${layout.gridStartX * scaleX}px, ${layout.top * scaleY}px)`;
+
+      slotHighlight.style.height = `${activeSlotHeight * scaleY}px`;
+      slotHighlight.style.width = `${layout.slotWidth * scaleX}px`;
+      slotHighlight.style.transform = `translate(${activeSlotLeft * scaleX}px, ${layout.top * scaleY}px)`;
+
+      cursor.style.height = `${activeSlotHeight * scaleY}px`;
+      cursor.style.transform = `translate(${cursorX * scaleX}px, ${layout.top * scaleY}px)`;
+
+      followTarget.style.top = `${activeMeasureCenterY * scaleY}px`;
+
+      if (lyric) {
+        lyricHighlight.textContent = lyric;
+        lyricHighlight.style.opacity = "1";
+        lyricHighlight.style.transform = `translate(${cursorX * scaleX}px, ${(layout.bottom - 28) * scaleY}px)`;
+      } else {
+        lyricHighlight.textContent = "";
+        lyricHighlight.style.opacity = "0";
+      }
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [activeLayout, measureLayouts, measures, playbackPosition, renderError, showLyrics]);
+
+  useEffect(() => {
+    const handleWindowScroll = () => disableFollowPlayback(false);
+    const handleUserScrollIntent = () => disableFollowPlayback(true);
+    window.addEventListener("scroll", handleWindowScroll, { passive: true });
+    window.addEventListener("wheel", handleUserScrollIntent, { passive: true });
+    window.addEventListener("touchmove", handleUserScrollIntent, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleWindowScroll);
+      window.removeEventListener("wheel", handleUserScrollIntent);
+      window.removeEventListener("touchmove", handleUserScrollIntent);
+    };
+  }, [disableFollowPlayback]);
+
+  useEffect(() => {
+    setVisiblePageIndex((current) => Math.min(current, Math.max(0, pages.length - 1)));
+    boardRefs.current = boardRefs.current.slice(0, pages.length);
+    cursorRefs.current = cursorRefs.current.slice(0, pages.length);
+    followTargetRefs.current = followTargetRefs.current.slice(0, pages.length);
+    lyricHighlightRefs.current = lyricHighlightRefs.current.slice(0, pages.length);
+    measureHighlightRefs.current = measureHighlightRefs.current.slice(0, pages.length);
+    overlayLayerRefs.current = overlayLayerRefs.current.slice(0, pages.length);
+    pageRefs.current = pageRefs.current.slice(0, pages.length);
+    slotHighlightRefs.current = slotHighlightRefs.current.slice(0, pages.length);
+    svgLayerRefs.current = svgLayerRefs.current.slice(0, pages.length);
+  }, [pages.length]);
+
+  const getPageScrollLeft = useCallback((pageIndex: number) => {
+    const viewport = viewportRef.current;
+    const firstPage = pageRefs.current[0];
+    const targetPage = pageRefs.current[pageIndex];
+    if (!viewport || !targetPage) {
+      return 0;
+    }
+    if (pageIndex <= 0 || !firstPage) {
+      return 0;
+    }
+
+    const secondPage = pageRefs.current[1];
+    const pageStride = secondPage && firstPage ? secondPage.offsetLeft - firstPage.offsetLeft : firstPage.offsetWidth;
+    return Math.max(0, pageStride * pageIndex);
+  }, []);
+
+  const scrollToPage = useCallback(
+    (pageIndex: number, behavior: ScrollBehavior = "smooth") => {
+      if (!pageRefs.current[pageIndex]) {
+        return;
+      }
+
+      autoScrollGuardUntilRef.current = performance.now() + AUTO_SCROLL_GUARD_MS;
+      setVisiblePageIndex((current) => (current === pageIndex ? current : pageIndex));
+      if (behavior === "auto") {
+        const targetLeft = getPageScrollLeft(pageIndex);
+        setPageTranslateX((current) => (Math.abs(current - targetLeft) < 1 ? current : targetLeft));
+      }
+    },
+    [getPageScrollLeft],
+  );
+
+  useEffect(() => {
+    if (pages.length === 0) {
+      setPageTranslateX(0);
+      return;
+    }
+
+    let frame = 0;
+    const syncPageTranslate = () => {
+      const targetLeft = getPageScrollLeft(visiblePageIndex);
+      setPageTranslateX((current) => (Math.abs(current - targetLeft) < 1 ? current : targetLeft));
+    };
+
+    frame = requestAnimationFrame(syncPageTranslate);
+    window.addEventListener("resize", syncPageTranslate);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", syncPageTranslate);
+    };
+  }, [getPageScrollLeft, pages.length, visiblePageIndex]);
+
+  const alignViewportToPlayback = useCallback(
+    (pageIndex: number, layout: MeasureLayout, behavior: ScrollBehavior, forceCenter: boolean) => {
+      const viewport = viewportRef.current;
+      const board = boardRefs.current[pageIndex];
+      if (!viewport || !board) {
+        return;
+      }
+
+      const targetLeft = getPageScrollLeft(pageIndex);
+      const scaleY = board.clientHeight / PAGE_HEIGHT_PX;
+      const lineCenterY = ((layout.top + layout.bottom) / 2) * scaleY;
+      const boardRect = board.getBoundingClientRect();
+      const cursorDocumentY = boardRect.top + window.scrollY + lineCenterY;
+      const deadZoneTop = window.innerHeight * 0.2;
+      const deadZoneBottom = window.innerHeight * 0.8;
+      const cursorViewportY = cursorDocumentY - window.scrollY;
+      const needsHorizontal = pageIndex !== visiblePageIndex || Math.abs(pageTranslateX - targetLeft) > 2;
+
+      let targetTop = window.scrollY;
+      let needsVertical = false;
+
+      if (forceCenter) {
+        targetTop = Math.max(0, cursorDocumentY - window.innerHeight / 2);
+        needsVertical = Math.abs(targetTop - window.scrollY) > 2;
+      } else if (cursorViewportY < deadZoneTop) {
+        targetTop = Math.max(0, cursorDocumentY - deadZoneTop);
+        needsVertical = true;
+      } else if (cursorViewportY > deadZoneBottom) {
+        targetTop = Math.max(0, cursorDocumentY - deadZoneBottom);
+        needsVertical = true;
+      }
+
+      if (!needsHorizontal && !needsVertical) {
+        return;
+      }
+
+      autoScrollGuardUntilRef.current = performance.now() + AUTO_SCROLL_GUARD_MS;
+      if (needsHorizontal) {
+        scrollToPage(pageIndex, behavior);
+      }
+      if (needsVertical) {
+        window.scrollTo({ behavior, top: targetTop });
+      }
+      setVisiblePageIndex((current) => (current === pageIndex ? current : pageIndex));
+    },
+    [getPageScrollLeft, pageTranslateX, scrollToPage, visiblePageIndex],
+  );
+
+  useEffect(() => {
+    const followWasEnabled = previousFollowPlaybackRef.current;
+    previousFollowPlaybackRef.current = followPlayback;
+
+    if (!followPlayback || pages.length === 0 || !activeLayout) {
+      if (!followPlayback) {
+        forceCenterNextAlignRef.current = false;
+        lastFollowTargetKeyRef.current = null;
+      }
+      return;
+    }
+
+    const followKey = `${activeLayout.pageIndex}:${activeLayout.top}`;
+    const followJustEnabled = !followWasEnabled && followPlayback;
+    const pageMismatch = visiblePageIndex !== targetPageIndex;
+    const lineMismatch = lastFollowTargetKeyRef.current !== followKey;
+    if (followJustEnabled || pageMismatch) {
+      forceCenterNextAlignRef.current = true;
+    }
+    if (pageMismatch) {
+      scrollToPage(targetPageIndex, followJustEnabled ? "auto" : "smooth");
+      return;
+    }
+
+    if (!followJustEnabled && !lineMismatch && !forceCenterNextAlignRef.current) {
+      return;
+    }
+
+    lastFollowTargetKeyRef.current = followKey;
+    const forceCenter = forceCenterNextAlignRef.current;
+    forceCenterNextAlignRef.current = false;
+    const behavior: ScrollBehavior = followJustEnabled ? "auto" : "smooth";
+
+    let frame = 0;
+    frame = requestAnimationFrame(() => {
+      alignViewportToPlayback(targetPageIndex, activeLayout, behavior, forceCenter);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [activeLayout, alignViewportToPlayback, followPlayback, pages.length, scrollToPage, targetPageIndex, visiblePageIndex]);
+
+  function handlePageNavigation(direction: -1 | 1) {
+    const nextPageIndex = clamp(visiblePageIndex + direction, 0, Math.max(0, pages.length - 1));
+    if (nextPageIndex === visiblePageIndex) {
+      return;
+    }
+
+    disableFollowPlayback(true);
+    scrollToPage(nextPageIndex);
+  }
+
+  function handleBoardClick(pageIndex: number, event: React.MouseEvent<HTMLDivElement>) {
+    if (renderError) {
+      return;
+    }
+
+    const board = boardRefs.current[pageIndex];
+    if (!onSeek || !board) {
+      return;
+    }
+
+    const rect = board.getBoundingClientRect();
+    const scaleX = PAGE_WIDTH_PX / rect.width;
+    const scaleY = PAGE_HEIGHT_PX / rect.height;
+    const x = (event.clientX - rect.left) * scaleX;
+    const y = (event.clientY - rect.top) * scaleY;
+    const layout = findMeasureLayoutAtPoint(
+      measureLayouts.filter((entry) => entry.pageIndex === pageIndex),
+      x,
+      y,
+    );
+    if (!layout) {
+      return;
+    }
+
+    const beatSeconds = 60 / Math.max(track.bpm || 120, 1);
+    const measureSeconds = beatSeconds * 4;
+    const fraction = clamp((x - layout.gridStartX) / (layout.gridEndX - layout.gridStartX), 0, 1);
+    onSeek((layout.measure - 1) * measureSeconds + fraction * measureSeconds);
+  }
+
+  return (
+    <div className="score-wrap" aria-label="Bass score with synchronized playback">
+      {renderError ? <div className="error">Score rendering failed: {renderError}</div> : null}
+      <div className="score-book-shell">
+        <button
+          aria-label="Previous page"
+          className="score-page-nav"
+          disabled={visiblePageIndex <= 0}
+          onClick={() => handlePageNavigation(-1)}
+          type="button"
+        >
+          Prev
+        </button>
+        <div className="score-book-viewport" ref={viewportRef}>
+          <div className="score-page-strip" style={{ transform: `translate3d(-${pageTranslateX}px, 0, 0)` }}>
+            {pages.map((page, pageIndex) => (
+              <div
+                className="score-page-shell"
+                key={`page-${page.measureStart}-${page.measureEnd}`}
+                ref={(node) => {
+                  pageRefs.current[pageIndex] = node;
+                }}
+              >
+                <div className="score-page-sheet">
+                  <div
+                    className={onSeek ? "score-board seekable score-page-board" : "score-board score-page-board"}
+                    onClick={(event) => handleBoardClick(pageIndex, event)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        if (onSeek) {
+                          const beatSeconds = 60 / Math.max(track.bpm || 120, 1);
+                          onSeek((page.measureStart - 1) * beatSeconds * 4);
+                        }
+                      }
+                    }}
+                    ref={(node) => {
+                      boardRefs.current[pageIndex] = node;
+                    }}
+                    role={onSeek ? "button" : undefined}
+                    tabIndex={onSeek ? 0 : undefined}
+                  >
+                    <div
+                      className="score-svg-layer"
+                      ref={(node) => {
+                        svgLayerRefs.current[pageIndex] = node;
+                      }}
+                    />
+                    <div
+                      className="score-overlay-layer"
+                      aria-hidden="true"
+                      ref={(node) => {
+                        overlayLayerRefs.current[pageIndex] = node;
+                      }}
+                    >
+                      <div
+                        className="playback-follow-target"
+                        ref={(node) => {
+                          followTargetRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-measure-highlight"
+                        ref={(node) => {
+                          measureHighlightRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-slot-highlight"
+                        ref={(node) => {
+                          slotHighlightRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-cursor"
+                        ref={(node) => {
+                          cursorRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-lyric-highlight"
+                        ref={(node) => {
+                          lyricHighlightRefs.current[pageIndex] = node;
+                        }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <button
+          aria-label="Next page"
+          className="score-page-nav"
+          disabled={visiblePageIndex >= Math.max(0, pages.length - 1)}
+          onClick={() => handlePageNavigation(1)}
+          type="button"
+        >
+          Next
+        </button>
+      </div>
+      {pages.length > 0 ? (
+        <div className="score-page-indicator">
+          Page {visiblePageIndex + 1} / {pages.length}
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+function resolveLineHeight(mode: BassRenderTrack["mode"], showLyrics: boolean): number {
+  if (mode === "standard") {
+    return showLyrics ? LINE_HEIGHT_STANDARD_LYRICS : LINE_HEIGHT_STANDARD;
+  }
+  if (mode === "tab") {
+    return showLyrics ? LINE_HEIGHT_TAB_LYRICS : LINE_HEIGHT_TAB;
+  }
+  return showLyrics ? LINE_HEIGHT_BOTH_LYRICS : LINE_HEIGHT_BOTH;
+}
+
+function collectPrintableSystems(
+  containers: Array<HTMLDivElement | null>,
+  pages: PageDescriptor[],
+): PrintableScoreSystem[] {
+  return pages.flatMap((page, pageIndex) => {
+    const sourceSvg = containers[pageIndex]?.querySelector("svg");
+    if (!sourceSvg) {
+      return [];
+    }
+
+    return [
+      {
+        height: PAGE_HEIGHT_PX,
+        measureEnd: page.measureEnd,
+        measureStart: page.measureStart,
+        svgMarkup: sourceSvg.outerHTML,
+        width: PAGE_WIDTH_PX,
+      },
+    ];
+  });
+}
+
+function paginateMeasures(
+  measures: BassMeasure[],
+  lineHeight: number,
+): { measureWidth: number; measuresPerPage: number; pages: PageDescriptor[] } {
+  const measuresPerLine = 1;
+  const innerHeight = PAGE_HEIGHT_PX - PAGE_PADDING_Y * 2;
+  const linesPerPage = Math.max(1, Math.floor(innerHeight / lineHeight));
+  const measuresPerPage = Math.max(1, measuresPerLine * linesPerPage);
+  const minimumMeasureWidth = SLOTS_PER_MEASURE * MIN_SLOT_WIDTH_PX + REGULAR_MEASURE_RESERVE_PX;
+  const innerWidth = PAGE_WIDTH_PX - PAGE_PADDING_X * 2;
+  const measureWidth = Math.max(minimumMeasureWidth, innerWidth / measuresPerLine);
+  const pages: PageDescriptor[] = [];
+
+  for (let startIndex = 0; startIndex < measures.length; startIndex += measuresPerPage) {
+    const endIndex = Math.min(measures.length, startIndex + measuresPerPage);
+    pages.push({
+      measureEnd: endIndex,
+      measureStart: startIndex + 1,
+      measures: measures.slice(startIndex, endIndex),
+    });
+  }
+
+  if (pages.length === 0) {
+    pages.push({
+      measureEnd: 1,
+      measureStart: 1,
+      measures: [{ notes: [], slots: emptySlots() }],
+    });
+  }
+
+  return { measureWidth, measuresPerPage, pages };
+}
+
+function buildBassDisplayTicks(measure: BassMeasure): BassDisplayTick[] {
+  const notesBySlot = new Map<number, BassRenderNote>();
+  for (const note of measure.notes) {
+    notesBySlot.set(note.slot, note);
+  }
+
+  const ticks: BassDisplayTick[] = [];
+  let slot = 0;
+  while (slot < SLOTS_PER_MEASURE) {
+    const note = notesBySlot.get(slot) ?? null;
+    if (note) {
+      const nextNoteSlot =
+        measure.notes.find((entry) => entry.slot > slot)?.slot ?? SLOTS_PER_MEASURE;
+      const durationSlots = Math.max(1, Math.min(note.durationSlots, nextNoteSlot - slot, SLOTS_PER_MEASURE - slot));
+      ticks.push({
+        duration: note.duration,
+        durationSlots,
+        note,
+        slot,
+      });
+      slot += durationSlots;
+      continue;
+    }
+
+    const nextOccupiedSlot =
+      measure.notes.find((entry) => entry.slot > slot)?.slot ?? SLOTS_PER_MEASURE;
+    let remaining = Math.max(1, nextOccupiedSlot - slot);
+    while (remaining > 0) {
+      const durationSlots = largestSupportedDuration(remaining);
+      ticks.push({
+        duration: durationFromSlots(durationSlots),
+        durationSlots,
+        note: null,
+        slot,
+      });
+      slot += durationSlots;
+      remaining -= durationSlots;
+    }
+  }
+
+  return ticks;
+}
+
+function largestSupportedDuration(remaining: number): 16 | 8 | 4 | 2 | 1 {
+  if (remaining >= 16) {
+    return 16;
+  }
+  if (remaining >= 8) {
+    return 8;
+  }
+  if (remaining >= 4) {
+    return 4;
+  }
+  if (remaining >= 2) {
+    return 2;
+  }
+  return 1;
+}
+
+function durationFromSlots(slots: number): "w" | "h" | "q" | "8" | "16" {
+  if (slots >= 16) {
+    return "w";
+  }
+  if (slots >= 8) {
+    return "h";
+  }
+  if (slots >= 4) {
+    return "q";
+  }
+  if (slots >= 2) {
+    return "8";
+  }
+  return "16";
+}
+
+function makeBassStandardNote(tick: BassDisplayTick): StaveNote {
+  if (!tick.note) {
+    return new StaveNote({
+      clef: "bass",
+      duration: `${tick.duration}r`,
+      keys: ["d/3"],
+    });
+  }
+
+  const note = new StaveNote({
+    auto_stem: false,
+    clef: "bass",
+    duration: tick.duration,
+    keys: [tick.note.displayStaffKey],
+    stem_direction: stemDirectionForKey(tick.note.displayStaffKey),
+    type: tick.note.isDead ? "x" : "n",
+  });
+
+  if (tick.note.isStaccato) {
+    note.addModifier(
+      new Articulation("a.").setPosition(
+        tick.note.displayStaffKey && stemDirectionForKey(tick.note.displayStaffKey) === 1
+          ? Modifier.Position.ABOVE
+          : Modifier.Position.BELOW,
+      ),
+      0,
+    );
+  }
+
+  if (tick.note.techniques.includes("HAMMER_ON")) {
+    note.addModifier(
+      new Annotation("H").setJustification("center").setVerticalJustification("top").setFont("Arial", 12, "bold"),
+      0,
+    );
+  } else if (tick.note.techniques.includes("PULL_OFF")) {
+    note.addModifier(
+      new Annotation("P").setJustification("center").setVerticalJustification("top").setFont("Arial", 12, "bold"),
+      0,
+    );
+  }
+
+  return note;
+}
+
+function drawTabNumbers(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  ticks: BassDisplayTick[],
+  standardNotes: StaveNote[],
+  tabStave: TabStave,
+  mode: BassRenderTrack["mode"],
+) {
+  if (mode === "standard") {
+    return;
+  }
+
+  context.save();
+  context.setFont("Arial, Malgun Gothic, sans-serif", TAB_TEXT_FONT_SIZE);
+  context.setFillStyle("#111317");
+  ticks.forEach((tick, index) => {
+    if (!tick.note) {
+      return;
+    }
+
+    const x = standardNotes[index] ? noteCenterX(standardNotes[index]) : slotToX(tabStave, tick.slot);
+    const y = tabStave.getYForLine(tick.note.string - 1);
+    const label = tick.note.fret === "X" ? "X" : String(tick.note.fret);
+    const width = Math.max(12, label.length * 9);
+
+    context.save();
+    context.setFillStyle("#ffffff");
+    context.fillRect(x - width / 2 - 2, y - 12, width + 4, 18);
+    context.restore();
+
+    context.fillText(label, x - width / 2, y + 5);
+
+    if (tick.note.isStaccato) {
+      context.beginPath();
+      context.arc(x, y - 16, 2.2, 0, Math.PI * 2, false);
+      context.fill();
+    }
+
+    if (tick.note.techniques.includes("SLAP")) {
+      context.fillText("T", x - 4, tabStave.getYForLine(3) + 24);
+    } else if (tick.note.techniques.includes("POP")) {
+      context.fillText("P", x - 4, tabStave.getYForLine(3) + 24);
+    }
+  });
+  context.restore();
+}
+
+function collectRenderedNotes(
+  ticks: BassDisplayTick[],
+  standardNotes: StaveNote[],
+  tabStave: TabStave,
+): RenderedBassNote[] {
+  return ticks.flatMap((tick, index) => {
+    if (!tick.note) {
+      return [];
+    }
+    const standardNote = standardNotes[index] ?? null;
+
+    return [
+      {
+        centerX: standardNote ? noteCenterX(standardNote) : slotToX(tabStave, tick.slot),
+        note: tick.note,
+        standardNote,
+        tabStave,
+      },
+    ];
+  });
+}
+
+function drawTechniqueConnections(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  renderedNotes: RenderedBassNote[],
+) {
+  for (let index = 0; index < renderedNotes.length; index += 1) {
+    const current = renderedNotes[index];
+    const next = renderedNotes[index + 1];
+    if (!current || !next) {
+      continue;
+    }
+
+    if (current.note.tieToNext) {
+      if (current.standardNote && next.standardNote) {
+        new StaveTie({
+          first_indices: [0],
+          first_note: current.standardNote,
+          last_indices: [0],
+          last_note: next.standardNote,
+        })
+          .setContext(context)
+          .draw();
+      } else {
+        drawTabArc(context, current, next);
+      }
+    }
+
+    if (current.note.techniques.includes("HAMMER_ON") || current.note.techniques.includes("PULL_OFF")) {
+      if (current.standardNote && next.standardNote) {
+        new Curve(current.standardNote, next.standardNote, {
+          cps: [
+            { x: 0, y: 8 },
+            { x: 0, y: 8 },
+          ],
+          position: "nearHead",
+          position_end: "nearHead",
+          y_shift: 6,
+        })
+          .setContext(context)
+          .draw();
+      } else {
+        drawTabArc(
+          context,
+          current,
+          next,
+          current.note.techniques.includes("HAMMER_ON") ? "H" : "P",
+        );
+      }
+    }
+
+    if (current.note.techniques.includes("SLIDE")) {
+      drawSlideLine(context, current, next);
+    }
+  }
+}
+
+function drawSlideLine(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  current: RenderedBassNote,
+  next: RenderedBassNote,
+) {
+  const y1 = current.tabStave.getYForLine(current.note.string - 1);
+  const y2 = next.tabStave.getYForLine(next.note.string - 1);
+  context.save();
+  context.setStrokeStyle("#111317");
+  context.setLineWidth(1.6);
+  context.beginPath();
+  context.moveTo(current.centerX + 8, y1 - 4);
+  context.lineTo(next.centerX - 8, y2 + 4);
+  context.stroke();
+  context.restore();
+}
+
+function drawTabArc(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  current: RenderedBassNote,
+  next: RenderedBassNote,
+  label?: "H" | "P",
+) {
+  const controlY = Math.min(current.tabStave.getYForLine(0), next.tabStave.getYForLine(0)) - 18;
+  const startX = current.centerX + 4;
+  const endX = next.centerX - 4;
+  const midX = (startX + endX) / 2;
+
+  context.save();
+  context.setStrokeStyle("#111317");
+  context.setFillStyle("#111317");
+  context.setLineWidth(1.3);
+  context.beginPath();
+  context.moveTo(startX, controlY + 8);
+  context.quadraticCurveTo(midX, controlY - 8, endX, controlY + 8);
+  context.stroke();
+  if (label) {
+    context.setFont("Arial", 11);
+    context.fillText(label, midX - 4, controlY - 10);
+  }
+  context.restore();
+}
+
+function noteCenterX(note: StaveNote): number {
+  return (note.getTieLeftX() + note.getTieRightX()) / 2;
+}
+
+function lyricsHostStave(mode: BassRenderTrack["mode"], standardStave: Stave, tabStave: TabStave): Stave {
+  return mode === "tab" ? tabStave : mode === "both" ? tabStave : standardStave;
+}
+
+function stemDirectionForKey(key: string): number {
+  return lineForKey(key) < 2 ? 1 : -1;
+}
+
+function lineForKey(key: string): number {
+  const match = /^([a-g])[#b]?\/(-?\d+)$/.exec(key);
+  if (!match) {
+    return 2;
+  }
+
+  const diatonicOrder: Record<string, number> = {
+    a: 5,
+    b: 6,
+    c: 0,
+    d: 1,
+    e: 2,
+    f: 3,
+    g: 4,
+  };
+
+  const index = Number(match[2]) * 7 + diatonicOrder[match[1]];
+  const bassMiddleLine = 3 * 7 + diatonicOrder.d;
+  return (index - bassMiddleLine) / 2;
+}
+
+function drawLyricLane(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  stave: Stave,
+  measure: BassMeasure,
+) {
+  context.save();
+  context.setFont("Arial, Malgun Gothic, sans-serif", LYRIC_FONT_SIZE);
+  let lastRight = Number.NEGATIVE_INFINITY;
+  const lyricY = stave.getYForLine(6) + 28;
+  measure.slots.forEach((slot, slotIndex) => {
+    const lyrics = slot.lyrics.length
+      ? slot.lyrics
+      : slot.lyric?.trim()
+        ? [{ lyric: slot.lyric, row: 0 }]
+        : [];
+    for (const slotLyric of lyrics) {
+      const lyric = slotLyric.lyric.trim().normalize("NFC");
+      if (!lyric) {
+        continue;
+      }
+
+      const x = slotToX(stave, slotIndex);
+      const width = lyricVisualWidth(lyric);
+      const desiredLeft = x - width / 2;
+      const left = Math.max(desiredLeft, lastRight + LYRIC_HORIZONTAL_PADDING_PX);
+      const right = left + width;
+
+      context.fillText(lyric, left, lyricY);
+      lastRight = right;
+    }
+  });
+  context.restore();
+}
+
+function lyricVisualWidth(text: string): number {
+  return Array.from(text).reduce((width, char) => {
+    if (isHangulSyllable(char)) {
+      return width + LYRIC_FONT_SIZE;
+    }
+    return width + 7;
+  }, 0);
+}
+
+function isHangulSyllable(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code >= 0xac00 && code <= 0xd7a3;
+}
+
+function slotToX(stave: Stave, slot: number): number {
+  const startX = stave.getNoteStartX();
+  const endX = stave.getNoteEndX();
+  return startX + ((slot + 0.5) / SLOTS_PER_MEASURE) * (endX - startX);
+}
+
+function measureLayoutFromStaves(
+  mode: BassRenderTrack["mode"],
+  standardStave: Stave,
+  tabStave: TabStave,
+  measure: number,
+  pageIndex: number,
+  showLyrics: boolean,
+): MeasureLayout {
+  const referenceStave = mode === "tab" ? tabStave : standardStave;
+  const slotZero = slotToX(referenceStave, 0);
+  const slotOne = slotToX(referenceStave, 1);
+  const slotWidth = Math.max(1, slotOne - slotZero);
+  const gridStartX = slotZero - slotWidth / 2;
+  const gridEndX = gridStartX + slotWidth * SLOTS_PER_MEASURE;
+
+  let top = referenceStave.getYForLine(0) - 38;
+  let bottom = mode === "tab" ? tabStave.getYForLine(3) + 32 : referenceStave.getYForLine(4) + 28;
+
+  if (mode === "both") {
+    top = standardStave.getYForLine(0) - 40;
+    bottom = tabStave.getYForLine(3) + 32;
+  }
+
+  if (showLyrics) {
+    bottom += 40;
+  }
+
+  return {
+    bottom,
+    gridEndX,
+    gridStartX,
+    measure,
+    pageIndex,
+    slotWidth,
+    top,
+  };
+}
+
+function timeToPlaybackPosition(currentTime: number, bpm: number, measureCount: number): PlaybackPosition {
+  const beatSeconds = 60 / Math.max(bpm || 120, 1);
+  const measureSeconds = beatSeconds * 4;
+  const slotSeconds = measureSeconds / SLOTS_PER_MEASURE;
+  const maxMeasureIndex = Math.max(0, measureCount - 1);
+  const measureIndex = Math.min(maxMeasureIndex, Math.max(0, Math.floor(currentTime / measureSeconds)));
+  const measureStart = measureIndex * measureSeconds;
+  const slotProgress = clamp((currentTime - measureStart) / slotSeconds, 0, SLOTS_PER_MEASURE);
+  const slot = Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, Math.floor(slotProgress)));
+
+  return {
+    measure: measureIndex + 1,
+    slot,
+    slotProgress,
+  };
+}
+
+function findMeasureLayoutAtPoint(layouts: MeasureLayout[], x: number, y: number): MeasureLayout | null {
+  return (
+    layouts.find(
+      (layout) =>
+        y >= layout.top - 28 &&
+        y <= layout.bottom + 28 &&
+        x >= layout.gridStartX - 36 &&
+        x <= layout.gridEndX + 36,
+    ) ?? null
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function drawMeasureNumber(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  measureNumber: number,
+  x: number,
+  y: number,
+) {
+  context.save();
+  context.setFont("Arial", 10);
+  context.fillText(String(measureNumber), x + 4, y - 3);
+  context.restore();
+}
+
+function emptySlots(): BassSlot[] {
+  return Array.from({ length: SLOTS_PER_MEASURE }, () => ({
+    lyric: null,
+    lyrics: [],
+    notes: [],
+  }));
+}

--- a/apps/web/components/MelodicSheet.tsx
+++ b/apps/web/components/MelodicSheet.tsx
@@ -1,0 +1,1012 @@
+"use client";
+
+import { Beam, Formatter, Renderer, Stave, StaveConnector, StaveNote, Voice } from "vexflow";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import type { DrumSheetHandle, PrintableScoreSystem } from "@/components/DrumSheet";
+import type { MelodicMeasure, MelodicNoteEvent, MelodicRenderTrack, MelodicSlot } from "@/lib/scoreTracks";
+
+type Props = {
+  audioCurrentTime?: number;
+  followPlayback?: boolean;
+  isPlaying?: boolean;
+  onFollowPlaybackChange?: (enabled: boolean) => void;
+  onSeek?: (time: number) => void;
+  showLyrics?: boolean;
+  track: MelodicRenderTrack;
+};
+
+type VoiceNumber = 1 | 2;
+
+type DisplayTick = {
+  duration: "q" | "8" | "16";
+  events: MelodicNoteEvent[];
+  hiddenRest?: boolean;
+  slot: number;
+};
+
+type MeasureLayout = {
+  bottom: number;
+  gridEndX: number;
+  gridStartX: number;
+  measure: number;
+  pageIndex: number;
+  slotWidth: number;
+  top: number;
+};
+
+type PageDescriptor = {
+  measureEnd: number;
+  measureStart: number;
+  measures: MelodicMeasure[];
+};
+
+type PlaybackPosition = {
+  measure: number;
+  slot: number;
+  slotProgress: number;
+};
+
+const PAGE_HEIGHT_PX = 1123;
+const PAGE_PADDING_X = 24;
+const PAGE_PADDING_Y = 34;
+const PAGE_WIDTH_PX = 794;
+const LINE_HEIGHT_SINGLE_WITH_LYRICS = 186;
+const LINE_HEIGHT_SINGLE_WITHOUT_LYRICS = 146;
+const LINE_HEIGHT_GRAND_WITH_LYRICS = 268;
+const LINE_HEIGHT_GRAND_WITHOUT_LYRICS = 226;
+const SLOTS_PER_MEASURE = 16;
+const MIN_SLOT_WIDTH_PX = 40;
+const FIRST_MEASURE_RESERVE_PX = 76;
+const REGULAR_MEASURE_RESERVE_PX = 24;
+const LYRIC_FONT_SIZE = 12;
+const LYRIC_HORIZONTAL_PADDING_PX = 5;
+const AUTO_SCROLL_GUARD_MS = 1000;
+const GRAND_STAFF_GAP_PX = 86;
+
+export const MelodicSheet = forwardRef<DrumSheetHandle, Props>(function MelodicSheet(
+  { audioCurrentTime = 0, followPlayback = true, isPlaying = false, onFollowPlaybackChange, onSeek, showLyrics = true, track }: Props,
+  ref,
+) {
+  const boardRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const cursorRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const followTargetRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const lyricHighlightRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const measureHighlightRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const overlayLayerRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const pageRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const slotHighlightRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const svgLayerRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const autoScrollGuardUntilRef = useRef(0);
+  const followPlaybackRef = useRef(followPlayback);
+  const isPlayingRef = useRef(isPlaying);
+  const forceCenterNextAlignRef = useRef(false);
+  const lastFollowTargetKeyRef = useRef<string | null>(null);
+  const previousFollowPlaybackRef = useRef(followPlayback);
+  const [measureLayouts, setMeasureLayouts] = useState<MeasureLayout[]>([]);
+  const [pageTranslateX, setPageTranslateX] = useState(0);
+  const [renderError, setRenderError] = useState<string | null>(null);
+  const [visiblePageIndex, setVisiblePageIndex] = useState(0);
+
+  const measures = track.measures;
+  const lineHeight =
+    track.notation === "grand"
+      ? showLyrics
+        ? LINE_HEIGHT_GRAND_WITH_LYRICS
+        : LINE_HEIGHT_GRAND_WITHOUT_LYRICS
+      : showLyrics
+        ? LINE_HEIGHT_SINGLE_WITH_LYRICS
+        : LINE_HEIGHT_SINGLE_WITHOUT_LYRICS;
+  const pagination = useMemo(() => paginateMeasures(measures, lineHeight), [lineHeight, measures]);
+  const pages = pagination.pages;
+  const measuresPerPage = pagination.measuresPerPage;
+  const measureWidth = pagination.measureWidth;
+  const playbackPosition = useMemo(
+    () => timeToPlaybackPosition(audioCurrentTime, track.bpm, measures.length),
+    [audioCurrentTime, measures.length, track.bpm],
+  );
+  const activeLayout = measureLayouts[playbackPosition.measure - 1] ?? null;
+  const targetPageIndex = useMemo(
+    () =>
+      pages.length > 0
+        ? clamp(Math.floor(Math.max(0, playbackPosition.measure - 1) / Math.max(1, measuresPerPage)), 0, pages.length - 1)
+        : 0,
+    [measuresPerPage, pages.length, playbackPosition.measure],
+  );
+
+  useEffect(() => {
+    followPlaybackRef.current = followPlayback;
+  }, [followPlayback]);
+
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  }, [isPlaying]);
+
+  const disableFollowPlayback = useCallback(
+    (ignoreGuard: boolean) => {
+      if (!followPlaybackRef.current || !isPlayingRef.current) {
+        return;
+      }
+      if (!ignoreGuard && performance.now() <= autoScrollGuardUntilRef.current) {
+        return;
+      }
+      onFollowPlaybackChange?.(false);
+    },
+    [onFollowPlaybackChange],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getPrintableSystems: () => collectPrintableSystems(svgLayerRefs.current, pages),
+    }),
+    [pages],
+  );
+
+  useEffect(() => {
+    const nextLayouts: MeasureLayout[] = [];
+
+    try {
+      pages.forEach((page, pageIndex) => {
+        const container = svgLayerRefs.current[pageIndex];
+        if (!container) {
+          return;
+        }
+
+        container.innerHTML = "";
+        const renderer = new Renderer(container, Renderer.Backends.SVG);
+        renderer.resize(PAGE_WIDTH_PX, PAGE_HEIGHT_PX);
+        const context = renderer.getContext();
+        context.setFont("Arial, Malgun Gothic, sans-serif", 12);
+
+        page.measures.forEach((measure, localIndex) => {
+          const globalIndex = page.measureStart - 1 + localIndex;
+          const x = PAGE_PADDING_X;
+          const y = PAGE_PADDING_Y + localIndex * lineHeight;
+          const staveWidth = measureWidth;
+
+          drawMeasureNumber(context, globalIndex + 1, x, y);
+
+          if (track.notation === "grand") {
+            const upperStave = new Stave(x, y, staveWidth);
+            const lowerStave = new Stave(x, y + GRAND_STAFF_GAP_PX, staveWidth);
+            if (localIndex === 0) {
+              upperStave.addClef("treble").addTimeSignature("4/4");
+              lowerStave.addClef("bass").addTimeSignature("4/4");
+            }
+            upperStave.setContext(context).draw();
+            lowerStave.setContext(context).draw();
+
+            new StaveConnector(upperStave, lowerStave).setType(StaveConnector.type.SINGLE_LEFT).setContext(context).draw();
+            if (localIndex === 0) {
+              new StaveConnector(upperStave, lowerStave).setType(StaveConnector.type.BRACE).setContext(context).draw();
+            }
+
+            const upperTicks = simplifyVoice(measure, 1);
+            const lowerTicks = simplifyVoice(measure, 2);
+            const upperNotes = upperTicks.map((tick) => makeMelodicNote(tick, "treble"));
+            const lowerNotes = lowerTicks.map((tick) => makeMelodicNote(tick, "bass"));
+            const upperVoice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
+            const lowerVoice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
+            upperVoice.addTickables(upperNotes);
+            lowerVoice.addTickables(lowerNotes);
+
+            const formatterWidth = staveWidth - (localIndex === 0 ? FIRST_MEASURE_RESERVE_PX : REGULAR_MEASURE_RESERVE_PX);
+            new Formatter().joinVoices([upperVoice]).joinVoices([lowerVoice]).format([upperVoice, lowerVoice], formatterWidth);
+
+            upperVoice.draw(context, upperStave);
+            lowerVoice.draw(context, lowerStave);
+            drawBeams(context, upperNotes);
+            drawBeams(context, lowerNotes);
+
+            if (showLyrics) {
+              drawLyricLane(context, lowerStave, measure);
+            }
+
+            nextLayouts[globalIndex] = measureLayoutFromGrandStaves(upperStave, lowerStave, globalIndex + 1, pageIndex, showLyrics);
+            return;
+          }
+
+          const stave = new Stave(x, y, staveWidth);
+          if (localIndex === 0) {
+            stave.addClef(track.clef).addTimeSignature("4/4");
+          }
+          stave.setContext(context).draw();
+
+          const mergedTicks = simplifyMergedVoice(measure);
+          const notes = mergedTicks.map((tick) => makeMelodicNote(tick, track.clef));
+          const voice = new Voice({ num_beats: 4, beat_value: 4 }).setStrict(true);
+          voice.addTickables(notes);
+
+          const formatterWidth = staveWidth - (localIndex === 0 ? FIRST_MEASURE_RESERVE_PX : REGULAR_MEASURE_RESERVE_PX);
+          new Formatter().joinVoices([voice]).format([voice], formatterWidth);
+
+          voice.draw(context, stave);
+          drawBeams(context, notes);
+
+          if (showLyrics) {
+            drawLyricLane(context, stave, measure);
+          }
+
+          nextLayouts[globalIndex] = measureLayoutFromSingleStave(stave, globalIndex + 1, pageIndex, showLyrics);
+        });
+      });
+
+      setRenderError(null);
+      setMeasureLayouts(nextLayouts);
+    } catch (error) {
+      console.error("MelodicSheet render failed", error);
+      svgLayerRefs.current.forEach((container) => {
+        if (container) {
+          container.innerHTML = "";
+        }
+      });
+      setMeasureLayouts([]);
+      setRenderError(error instanceof Error ? error.message : "Melodic score rendering failed.");
+    }
+  }, [lineHeight, measureWidth, pages, showLyrics, track.clef, track.notation]);
+
+  useEffect(() => {
+    if (renderError) {
+      return;
+    }
+
+    let frame = 0;
+    frame = requestAnimationFrame(() => {
+      const activePageIndex = activeLayout?.pageIndex ?? -1;
+
+      overlayLayerRefs.current.forEach((overlayLayer, pageIndex) => {
+        if (overlayLayer) {
+          overlayLayer.style.opacity = pageIndex === activePageIndex ? "1" : "0";
+        }
+      });
+
+      const followTarget = activePageIndex >= 0 ? followTargetRefs.current[activePageIndex] : null;
+      const measureHighlight = activePageIndex >= 0 ? measureHighlightRefs.current[activePageIndex] : null;
+      const overlayLayer = activePageIndex >= 0 ? overlayLayerRefs.current[activePageIndex] : null;
+      const slotHighlight = activePageIndex >= 0 ? slotHighlightRefs.current[activePageIndex] : null;
+      const cursor = activePageIndex >= 0 ? cursorRefs.current[activePageIndex] : null;
+      const lyricHighlight = activePageIndex >= 0 ? lyricHighlightRefs.current[activePageIndex] : null;
+      const board = activePageIndex >= 0 ? boardRefs.current[activePageIndex] : null;
+      const layout = measureLayouts[playbackPosition.measure - 1] ?? null;
+      const measure = measures[playbackPosition.measure - 1] ?? null;
+      const slot = measure?.slots[playbackPosition.slot] ?? null;
+      const lyric = showLyrics
+        ? (slot?.lyrics[0]?.lyric?.trim().normalize("NFC") ?? slot?.lyric?.trim().normalize("NFC") ?? null)
+        : null;
+
+      if (!followTarget || !measureHighlight || !overlayLayer || !slotHighlight || !cursor || !lyricHighlight || !board) {
+        return;
+      }
+
+      if (!layout) {
+        overlayLayer.style.opacity = "0";
+        measureHighlight.style.opacity = "0";
+        lyricHighlight.style.opacity = "0";
+        return;
+      }
+
+      const cursorX =
+        layout.gridStartX + (playbackPosition.slotProgress / SLOTS_PER_MEASURE) * (layout.gridEndX - layout.gridStartX);
+      const activeSlotLeft = layout.gridStartX + playbackPosition.slot * layout.slotWidth;
+      const activeMeasureWidth = layout.gridEndX - layout.gridStartX;
+      const activeSlotHeight = layout.bottom - layout.top;
+      const activeMeasureCenterY = (layout.top + layout.bottom) / 2;
+      const boardRect = board.getBoundingClientRect();
+      const scaleX = boardRect.width / PAGE_WIDTH_PX;
+      const scaleY = boardRect.height / PAGE_HEIGHT_PX;
+
+      overlayLayer.style.opacity = "1";
+      measureHighlight.style.opacity = "1";
+      measureHighlight.style.height = `${activeSlotHeight * scaleY}px`;
+      measureHighlight.style.width = `${activeMeasureWidth * scaleX}px`;
+      measureHighlight.style.transform = `translate(${layout.gridStartX * scaleX}px, ${layout.top * scaleY}px)`;
+
+      slotHighlight.style.height = `${activeSlotHeight * scaleY}px`;
+      slotHighlight.style.width = `${layout.slotWidth * scaleX}px`;
+      slotHighlight.style.transform = `translate(${activeSlotLeft * scaleX}px, ${layout.top * scaleY}px)`;
+
+      cursor.style.height = `${activeSlotHeight * scaleY}px`;
+      cursor.style.transform = `translate(${cursorX * scaleX}px, ${layout.top * scaleY}px)`;
+
+      followTarget.style.top = `${activeMeasureCenterY * scaleY}px`;
+
+      if (lyric) {
+        lyricHighlight.textContent = lyric;
+        lyricHighlight.style.opacity = "1";
+        lyricHighlight.style.transform = `translate(${cursorX * scaleX}px, ${(layout.bottom - 28) * scaleY}px)`;
+      } else {
+        lyricHighlight.textContent = "";
+        lyricHighlight.style.opacity = "0";
+      }
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [activeLayout, measureLayouts, measures, playbackPosition, renderError, showLyrics]);
+
+  useEffect(() => {
+    const handleWindowScroll = () => disableFollowPlayback(false);
+    const handleUserScrollIntent = () => disableFollowPlayback(true);
+    window.addEventListener("scroll", handleWindowScroll, { passive: true });
+    window.addEventListener("wheel", handleUserScrollIntent, { passive: true });
+    window.addEventListener("touchmove", handleUserScrollIntent, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleWindowScroll);
+      window.removeEventListener("wheel", handleUserScrollIntent);
+      window.removeEventListener("touchmove", handleUserScrollIntent);
+    };
+  }, [disableFollowPlayback]);
+
+  useEffect(() => {
+    setVisiblePageIndex((current) => Math.min(current, Math.max(0, pages.length - 1)));
+    boardRefs.current = boardRefs.current.slice(0, pages.length);
+    cursorRefs.current = cursorRefs.current.slice(0, pages.length);
+    followTargetRefs.current = followTargetRefs.current.slice(0, pages.length);
+    lyricHighlightRefs.current = lyricHighlightRefs.current.slice(0, pages.length);
+    measureHighlightRefs.current = measureHighlightRefs.current.slice(0, pages.length);
+    overlayLayerRefs.current = overlayLayerRefs.current.slice(0, pages.length);
+    pageRefs.current = pageRefs.current.slice(0, pages.length);
+    slotHighlightRefs.current = slotHighlightRefs.current.slice(0, pages.length);
+    svgLayerRefs.current = svgLayerRefs.current.slice(0, pages.length);
+  }, [pages.length]);
+
+  const getPageScrollLeft = useCallback((pageIndex: number) => {
+    const viewport = viewportRef.current;
+    const firstPage = pageRefs.current[0];
+    const targetPage = pageRefs.current[pageIndex];
+    if (!viewport || !targetPage) {
+      return 0;
+    }
+    if (pageIndex <= 0 || !firstPage) {
+      return 0;
+    }
+
+    const secondPage = pageRefs.current[1];
+    const pageStride = secondPage && firstPage ? secondPage.offsetLeft - firstPage.offsetLeft : firstPage.offsetWidth;
+    return Math.max(0, pageStride * pageIndex);
+  }, []);
+
+  const scrollToPage = useCallback(
+    (pageIndex: number, behavior: ScrollBehavior = "smooth") => {
+      if (!pageRefs.current[pageIndex]) {
+        return;
+      }
+
+      autoScrollGuardUntilRef.current = performance.now() + AUTO_SCROLL_GUARD_MS;
+      setVisiblePageIndex((current) => (current === pageIndex ? current : pageIndex));
+      if (behavior === "auto") {
+        const targetLeft = getPageScrollLeft(pageIndex);
+        setPageTranslateX((current) => (Math.abs(current - targetLeft) < 1 ? current : targetLeft));
+      }
+    },
+    [getPageScrollLeft],
+  );
+
+  useEffect(() => {
+    if (pages.length === 0) {
+      setPageTranslateX(0);
+      return;
+    }
+
+    let frame = 0;
+    const syncPageTranslate = () => {
+      const targetLeft = getPageScrollLeft(visiblePageIndex);
+      setPageTranslateX((current) => (Math.abs(current - targetLeft) < 1 ? current : targetLeft));
+    };
+
+    frame = requestAnimationFrame(syncPageTranslate);
+    window.addEventListener("resize", syncPageTranslate);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", syncPageTranslate);
+    };
+  }, [getPageScrollLeft, pages.length, visiblePageIndex]);
+
+  const alignViewportToPlayback = useCallback(
+    (pageIndex: number, layout: MeasureLayout, behavior: ScrollBehavior, forceCenter: boolean) => {
+      const viewport = viewportRef.current;
+      const board = boardRefs.current[pageIndex];
+      if (!viewport || !board) {
+        return;
+      }
+
+      const targetLeft = getPageScrollLeft(pageIndex);
+      const scaleY = board.clientHeight / PAGE_HEIGHT_PX;
+      const lineCenterY = ((layout.top + layout.bottom) / 2) * scaleY;
+      const boardRect = board.getBoundingClientRect();
+      const cursorDocumentY = boardRect.top + window.scrollY + lineCenterY;
+      const deadZoneTop = window.innerHeight * 0.2;
+      const deadZoneBottom = window.innerHeight * 0.8;
+      const cursorViewportY = cursorDocumentY - window.scrollY;
+      const needsHorizontal = pageIndex !== visiblePageIndex || Math.abs(pageTranslateX - targetLeft) > 2;
+
+      let targetTop = window.scrollY;
+      let needsVertical = false;
+
+      if (forceCenter) {
+        targetTop = Math.max(0, cursorDocumentY - window.innerHeight / 2);
+        needsVertical = Math.abs(targetTop - window.scrollY) > 2;
+      } else if (cursorViewportY < deadZoneTop) {
+        targetTop = Math.max(0, cursorDocumentY - deadZoneTop);
+        needsVertical = true;
+      } else if (cursorViewportY > deadZoneBottom) {
+        targetTop = Math.max(0, cursorDocumentY - deadZoneBottom);
+        needsVertical = true;
+      }
+
+      if (!needsHorizontal && !needsVertical) {
+        return;
+      }
+
+      autoScrollGuardUntilRef.current = performance.now() + AUTO_SCROLL_GUARD_MS;
+      if (needsHorizontal) {
+        scrollToPage(pageIndex, behavior);
+      }
+      if (needsVertical) {
+        window.scrollTo({ behavior, top: targetTop });
+      }
+      setVisiblePageIndex((current) => (current === pageIndex ? current : pageIndex));
+    },
+    [getPageScrollLeft, pageTranslateX, scrollToPage, visiblePageIndex],
+  );
+
+  useEffect(() => {
+    const followWasEnabled = previousFollowPlaybackRef.current;
+    previousFollowPlaybackRef.current = followPlayback;
+
+    if (!followPlayback || pages.length === 0 || !activeLayout) {
+      if (!followPlayback) {
+        forceCenterNextAlignRef.current = false;
+        lastFollowTargetKeyRef.current = null;
+      }
+      return;
+    }
+
+    const followKey = `${activeLayout.pageIndex}:${activeLayout.top}`;
+    const followJustEnabled = !followWasEnabled && followPlayback;
+    const pageMismatch = visiblePageIndex !== targetPageIndex;
+    const lineMismatch = lastFollowTargetKeyRef.current !== followKey;
+    if (followJustEnabled || pageMismatch) {
+      forceCenterNextAlignRef.current = true;
+    }
+    if (pageMismatch) {
+      scrollToPage(targetPageIndex, followJustEnabled ? "auto" : "smooth");
+      return;
+    }
+
+    if (!followJustEnabled && !lineMismatch && !forceCenterNextAlignRef.current) {
+      return;
+    }
+
+    lastFollowTargetKeyRef.current = followKey;
+    const forceCenter = forceCenterNextAlignRef.current;
+    forceCenterNextAlignRef.current = false;
+    const behavior: ScrollBehavior = followJustEnabled ? "auto" : "smooth";
+
+    let frame = 0;
+    frame = requestAnimationFrame(() => {
+      alignViewportToPlayback(targetPageIndex, activeLayout, behavior, forceCenter);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [activeLayout, alignViewportToPlayback, followPlayback, pages.length, scrollToPage, targetPageIndex, visiblePageIndex]);
+
+  function handlePageNavigation(direction: -1 | 1) {
+    const nextPageIndex = clamp(visiblePageIndex + direction, 0, Math.max(0, pages.length - 1));
+    if (nextPageIndex === visiblePageIndex) {
+      return;
+    }
+
+    disableFollowPlayback(true);
+    scrollToPage(nextPageIndex);
+  }
+
+  function handleBoardClick(pageIndex: number, event: React.MouseEvent<HTMLDivElement>) {
+    if (renderError) {
+      return;
+    }
+
+    const board = boardRefs.current[pageIndex];
+    if (!onSeek || !board) {
+      return;
+    }
+
+    const rect = board.getBoundingClientRect();
+    const scaleX = PAGE_WIDTH_PX / rect.width;
+    const scaleY = PAGE_HEIGHT_PX / rect.height;
+    const x = (event.clientX - rect.left) * scaleX;
+    const y = (event.clientY - rect.top) * scaleY;
+    const layout = findMeasureLayoutAtPoint(
+      measureLayouts.filter((entry) => entry.pageIndex === pageIndex),
+      x,
+      y,
+    );
+    if (!layout) {
+      return;
+    }
+
+    const beatSeconds = 60 / Math.max(track.bpm || 120, 1);
+    const measureSeconds = beatSeconds * 4;
+    const fraction = clamp((x - layout.gridStartX) / (layout.gridEndX - layout.gridStartX), 0, 1);
+    onSeek((layout.measure - 1) * measureSeconds + fraction * measureSeconds);
+  }
+
+  return (
+    <div className="score-wrap" aria-label={`${track.label} score with synchronized playback`}>
+      {renderError ? <div className="error">Score rendering failed: {renderError}</div> : null}
+      <div className="score-book-shell">
+        <button
+          aria-label="Previous page"
+          className="score-page-nav"
+          disabled={visiblePageIndex <= 0}
+          onClick={() => handlePageNavigation(-1)}
+          type="button"
+        >
+          Prev
+        </button>
+        <div className="score-book-viewport" ref={viewportRef}>
+          <div className="score-page-strip" style={{ transform: `translate3d(-${pageTranslateX}px, 0, 0)` }}>
+            {pages.map((page, pageIndex) => (
+              <div
+                className="score-page-shell"
+                key={`page-${page.measureStart}-${page.measureEnd}`}
+                ref={(node) => {
+                  pageRefs.current[pageIndex] = node;
+                }}
+              >
+                <div className="score-page-sheet">
+                  <div
+                    className={onSeek ? "score-board seekable score-page-board" : "score-board score-page-board"}
+                    onClick={(event) => handleBoardClick(pageIndex, event)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        if (onSeek) {
+                          const beatSeconds = 60 / Math.max(track.bpm || 120, 1);
+                          onSeek((page.measureStart - 1) * beatSeconds * 4);
+                        }
+                      }
+                    }}
+                    ref={(node) => {
+                      boardRefs.current[pageIndex] = node;
+                    }}
+                    role={onSeek ? "button" : undefined}
+                    tabIndex={onSeek ? 0 : undefined}
+                  >
+                    <div
+                      className="score-svg-layer"
+                      ref={(node) => {
+                        svgLayerRefs.current[pageIndex] = node;
+                      }}
+                    />
+                    <div
+                      className="score-overlay-layer"
+                      aria-hidden="true"
+                      ref={(node) => {
+                        overlayLayerRefs.current[pageIndex] = node;
+                      }}
+                    >
+                      <div
+                        className="playback-follow-target"
+                        ref={(node) => {
+                          followTargetRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-measure-highlight"
+                        ref={(node) => {
+                          measureHighlightRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-slot-highlight"
+                        ref={(node) => {
+                          slotHighlightRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-cursor"
+                        ref={(node) => {
+                          cursorRefs.current[pageIndex] = node;
+                        }}
+                      />
+                      <div
+                        className="playback-lyric-highlight"
+                        ref={(node) => {
+                          lyricHighlightRefs.current[pageIndex] = node;
+                        }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <button
+          aria-label="Next page"
+          className="score-page-nav"
+          disabled={visiblePageIndex >= Math.max(0, pages.length - 1)}
+          onClick={() => handlePageNavigation(1)}
+          type="button"
+        >
+          Next
+        </button>
+      </div>
+      {pages.length > 0 ? (
+        <div className="score-page-indicator">
+          Page {visiblePageIndex + 1} / {pages.length}
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+function collectPrintableSystems(
+  containers: Array<HTMLDivElement | null>,
+  pages: PageDescriptor[],
+): PrintableScoreSystem[] {
+  return pages.flatMap((page, pageIndex) => {
+    const sourceSvg = containers[pageIndex]?.querySelector("svg");
+    if (!sourceSvg) {
+      return [];
+    }
+
+    return [
+      {
+        height: PAGE_HEIGHT_PX,
+        measureEnd: page.measureEnd,
+        measureStart: page.measureStart,
+        svgMarkup: sourceSvg.outerHTML,
+        width: PAGE_WIDTH_PX,
+      },
+    ];
+  });
+}
+
+function paginateMeasures(
+  measures: MelodicMeasure[],
+  lineHeight: number,
+): { measureWidth: number; measuresPerPage: number; pages: PageDescriptor[] } {
+  const measuresPerLine = 1;
+  const innerHeight = PAGE_HEIGHT_PX - PAGE_PADDING_Y * 2;
+  const linesPerPage = Math.max(1, Math.floor(innerHeight / lineHeight));
+  const measuresPerPage = Math.max(1, measuresPerLine * linesPerPage);
+  const minimumMeasureWidth = SLOTS_PER_MEASURE * MIN_SLOT_WIDTH_PX + REGULAR_MEASURE_RESERVE_PX;
+  const innerWidth = PAGE_WIDTH_PX - PAGE_PADDING_X * 2;
+  const measureWidth = Math.max(minimumMeasureWidth, innerWidth / measuresPerLine);
+  const pages: PageDescriptor[] = [];
+
+  for (let startIndex = 0; startIndex < measures.length; startIndex += measuresPerPage) {
+    const endIndex = Math.min(measures.length, startIndex + measuresPerPage);
+    pages.push({
+      measureEnd: endIndex,
+      measureStart: startIndex + 1,
+      measures: measures.slice(startIndex, endIndex),
+    });
+  }
+
+  if (pages.length === 0) {
+    pages.push({
+      measureEnd: 1,
+      measureStart: 1,
+      measures: [{ slots: emptySlots() }],
+    });
+  }
+
+  return { measureWidth, measuresPerPage, pages };
+}
+
+function simplifyVoice(measure: MelodicMeasure, voice: VoiceNumber): DisplayTick[] {
+  const result: DisplayTick[] = [];
+
+  for (let beatStart = 0; beatStart < SLOTS_PER_MEASURE; beatStart += 4) {
+    const slots = [0, 1, 2, 3].map((offset) => beatStart + offset);
+    const occupied = slots.filter((slot) => getVoiceEvents(measure.slots[slot], voice).length > 0);
+
+    if (occupied.length === 0) {
+      result.push({ duration: "q", events: [], hiddenRest: true, slot: beatStart });
+      continue;
+    }
+
+    if (occupied.length === 1 && occupied[0] === beatStart) {
+      result.push({ duration: "q", events: getVoiceEvents(measure.slots[beatStart], voice), slot: beatStart });
+      continue;
+    }
+
+    if (occupied.every((slot) => slot % 2 === 0)) {
+      for (const slot of [beatStart, beatStart + 2]) {
+        const events = getVoiceEvents(measure.slots[slot], voice);
+        result.push({
+          duration: "8",
+          events,
+          hiddenRest: events.length === 0,
+          slot,
+        });
+      }
+      continue;
+    }
+
+    for (const slot of slots) {
+      const events = getVoiceEvents(measure.slots[slot], voice);
+      result.push({
+        duration: "16",
+        events,
+        hiddenRest: events.length === 0,
+        slot,
+      });
+    }
+  }
+
+  return result;
+}
+
+function simplifyMergedVoice(measure: MelodicMeasure): DisplayTick[] {
+  const result: DisplayTick[] = [];
+
+  for (let beatStart = 0; beatStart < SLOTS_PER_MEASURE; beatStart += 4) {
+    const slots = [0, 1, 2, 3].map((offset) => beatStart + offset);
+    const occupied = slots.filter((slot) => mergeSlotEvents(measure.slots[slot]).length > 0);
+
+    if (occupied.length === 0) {
+      result.push({ duration: "q", events: [], hiddenRest: true, slot: beatStart });
+      continue;
+    }
+
+    if (occupied.length === 1 && occupied[0] === beatStart) {
+      result.push({ duration: "q", events: mergeSlotEvents(measure.slots[beatStart]), slot: beatStart });
+      continue;
+    }
+
+    if (occupied.every((slot) => slot % 2 === 0)) {
+      for (const slot of [beatStart, beatStart + 2]) {
+        const events = mergeSlotEvents(measure.slots[slot]);
+        result.push({
+          duration: "8",
+          events,
+          hiddenRest: events.length === 0,
+          slot,
+        });
+      }
+      continue;
+    }
+
+    for (const slot of slots) {
+      const events = mergeSlotEvents(measure.slots[slot]);
+      result.push({
+        duration: "16",
+        events,
+        hiddenRest: events.length === 0,
+        slot,
+      });
+    }
+  }
+
+  return result;
+}
+
+function makeMelodicNote(tick: DisplayTick, clef: "bass" | "treble"): StaveNote {
+  const keys = uniqueSortedKeys(tick.events, clef);
+  const stemDirection = keys.length > 0 ? stemDirectionForKeys(keys, clef) : 1;
+
+  return new StaveNote({
+    auto_stem: false,
+    clef,
+    duration: tick.hiddenRest || keys.length === 0 ? `${tick.duration}r` : tick.duration,
+    keys: keys.length > 0 ? keys : [restKeyForClef(clef)],
+    stem_direction: stemDirection,
+  });
+}
+
+function drawBeams(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  notes: StaveNote[],
+) {
+  Beam.generateBeams(notes).forEach((beam) => beam.setContext(context).draw());
+}
+
+function uniqueSortedKeys(events: MelodicNoteEvent[], clef: "bass" | "treble"): string[] {
+  const unique = Array.from(new Set(events.map((event) => event.staffKey)));
+  return unique.sort((left, right) => lineForKey(left, clef) - lineForKey(right, clef));
+}
+
+function stemDirectionForKeys(keys: string[], clef: "bass" | "treble"): number {
+  const averageLine = keys.reduce((total, key) => total + lineForKey(key, clef), 0) / Math.max(keys.length, 1);
+  return averageLine < 2 ? 1 : -1;
+}
+
+function restKeyForClef(clef: "bass" | "treble"): string {
+  return clef === "bass" ? "d/3" : "b/4";
+}
+
+function lineForKey(key: string, clef: "bass" | "treble"): number {
+  const match = /^([a-g])[#b]?\/(-?\d+)$/.exec(key);
+  if (!match) {
+    return 2;
+  }
+
+  const diatonicOrder: Record<string, number> = {
+    a: 5,
+    b: 6,
+    c: 0,
+    d: 1,
+    e: 2,
+    f: 3,
+    g: 4,
+  };
+
+  const index = Number(match[2]) * 7 + diatonicOrder[match[1]];
+  const base = clef === "bass" ? 2 * 7 + diatonicOrder.g : 4 * 7 + diatonicOrder.e;
+  return (index - base) / 2;
+}
+
+function getVoiceEvents(slot: MelodicSlot, voice: VoiceNumber): MelodicNoteEvent[] {
+  return voice === 1 ? slot.voice1 : slot.voice2;
+}
+
+function mergeSlotEvents(slot: MelodicSlot): MelodicNoteEvent[] {
+  const merged = [...slot.voice1, ...slot.voice2];
+  const byKey = new Map<string, MelodicNoteEvent>();
+  for (const event of merged) {
+    const current = byKey.get(event.staffKey);
+    if (!current || event.confidence > current.confidence) {
+      byKey.set(event.staffKey, event);
+    }
+  }
+  return Array.from(byKey.values()).sort((left, right) => lineForKey(left.staffKey, "treble") - lineForKey(right.staffKey, "treble"));
+}
+
+function emptySlots(): MelodicSlot[] {
+  return Array.from({ length: SLOTS_PER_MEASURE }, () => ({
+    lyric: null,
+    lyrics: [],
+    voice1: [],
+    voice2: [],
+  }));
+}
+
+function drawLyricLane(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  stave: Stave,
+  measure: MelodicMeasure,
+) {
+  context.save();
+  context.setFont("Arial, Malgun Gothic, sans-serif", LYRIC_FONT_SIZE);
+  let lastRight = Number.NEGATIVE_INFINITY;
+  const lyricY = stave.getYForLine(6) + 28;
+  measure.slots.forEach((slot, slotIndex) => {
+    const lyrics = slot.lyrics.length
+      ? slot.lyrics
+      : slot.lyric?.trim()
+        ? [{ lyric: slot.lyric, row: 0 }]
+        : [];
+    for (const slotLyric of lyrics) {
+      const lyric = slotLyric.lyric.trim().normalize("NFC");
+      if (!lyric) {
+        continue;
+      }
+
+      const x = slotToX(stave, slotIndex);
+      const width = lyricVisualWidth(lyric);
+      const desiredLeft = x - width / 2;
+      const left = Math.max(desiredLeft, lastRight + LYRIC_HORIZONTAL_PADDING_PX);
+      const right = left + width;
+
+      context.fillText(lyric, left, lyricY);
+      lastRight = right;
+    }
+  });
+  context.restore();
+}
+
+function lyricVisualWidth(text: string): number {
+  return Array.from(text).reduce((width, char) => {
+    if (isHangulSyllable(char)) {
+      return width + LYRIC_FONT_SIZE;
+    }
+    return width + 7;
+  }, 0);
+}
+
+function isHangulSyllable(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code >= 0xac00 && code <= 0xd7a3;
+}
+
+function slotToX(stave: Stave, slot: number): number {
+  const startX = stave.getNoteStartX();
+  const endX = stave.getNoteEndX();
+  return startX + ((slot + 0.5) / SLOTS_PER_MEASURE) * (endX - startX);
+}
+
+function measureLayoutFromSingleStave(stave: Stave, measure: number, pageIndex: number, showLyrics: boolean): MeasureLayout {
+  const slotZero = slotToX(stave, 0);
+  const slotOne = slotToX(stave, 1);
+  const slotWidth = Math.max(1, slotOne - slotZero);
+  const gridStartX = slotZero - slotWidth / 2;
+  const gridEndX = gridStartX + slotWidth * SLOTS_PER_MEASURE;
+  const top = stave.getYForLine(0) - 40;
+  const bottom = showLyrics ? stave.getYForLine(6) + 52 : stave.getYForLine(4) + 26;
+
+  return {
+    bottom,
+    gridEndX,
+    gridStartX,
+    measure,
+    pageIndex,
+    slotWidth,
+    top,
+  };
+}
+
+function measureLayoutFromGrandStaves(
+  upperStave: Stave,
+  lowerStave: Stave,
+  measure: number,
+  pageIndex: number,
+  showLyrics: boolean,
+): MeasureLayout {
+  const slotZero = slotToX(upperStave, 0);
+  const slotOne = slotToX(upperStave, 1);
+  const slotWidth = Math.max(1, slotOne - slotZero);
+  const gridStartX = slotZero - slotWidth / 2;
+  const gridEndX = gridStartX + slotWidth * SLOTS_PER_MEASURE;
+  const top = upperStave.getYForLine(0) - 42;
+  const bottom = showLyrics ? lowerStave.getYForLine(6) + 52 : lowerStave.getYForLine(4) + 28;
+
+  return {
+    bottom,
+    gridEndX,
+    gridStartX,
+    measure,
+    pageIndex,
+    slotWidth,
+    top,
+  };
+}
+
+function timeToPlaybackPosition(currentTime: number, bpm: number, measureCount: number): PlaybackPosition {
+  const beatSeconds = 60 / Math.max(bpm || 120, 1);
+  const measureSeconds = beatSeconds * 4;
+  const slotSeconds = measureSeconds / SLOTS_PER_MEASURE;
+  const maxMeasureIndex = Math.max(0, measureCount - 1);
+  const measureIndex = Math.min(maxMeasureIndex, Math.max(0, Math.floor(currentTime / measureSeconds)));
+  const measureStart = measureIndex * measureSeconds;
+  const slotProgress = clamp((currentTime - measureStart) / slotSeconds, 0, SLOTS_PER_MEASURE);
+  const slot = Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, Math.floor(slotProgress)));
+
+  return {
+    measure: measureIndex + 1,
+    slot,
+    slotProgress,
+  };
+}
+
+function findMeasureLayoutAtPoint(layouts: MeasureLayout[], x: number, y: number): MeasureLayout | null {
+  return (
+    layouts.find(
+      (layout) =>
+        y >= layout.top - 28 &&
+        y <= layout.bottom + 28 &&
+        x >= layout.gridStartX - 36 &&
+        x <= layout.gridEndX + 36,
+    ) ?? null
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function drawMeasureNumber(
+  context: ReturnType<InstanceType<typeof Renderer>["getContext"]>,
+  measureNumber: number,
+  x: number,
+  y: number,
+) {
+  context.save();
+  context.setFont("Arial", 10);
+  context.fillText(String(measureNumber), x + 4, y - 3);
+  context.restore();
+}

--- a/apps/web/components/ScoreSheet.tsx
+++ b/apps/web/components/ScoreSheet.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
+import { DrumSheet, type DrumSheetHandle, type PrintableScoreSystem } from "@/components/DrumSheet";
+import { MelodicSheet } from "@/components/MelodicSheet";
+import { resolveInstrumentView } from "@/lib/scoreTracks";
+import type { AnalysisResult, InstrumentType } from "@/lib/types";
+
+type Props = {
+  audioCurrentTime?: number;
+  followPlayback?: boolean;
+  instrument: InstrumentType;
+  isPlaying?: boolean;
+  onFollowPlaybackChange?: (enabled: boolean) => void;
+  onSeek?: (time: number) => void;
+  score: AnalysisResult;
+  showLyrics?: boolean;
+};
+
+export type ScoreSheetHandle = {
+  getPrintableSystems: () => PrintableScoreSystem[];
+};
+
+export const ScoreSheet = forwardRef<ScoreSheetHandle, Props>(function ScoreSheet(
+  { audioCurrentTime = 0, followPlayback = true, instrument, isPlaying = false, onFollowPlaybackChange, onSeek, score, showLyrics = true }: Props,
+  ref,
+) {
+  const innerRef = useRef<DrumSheetHandle | null>(null);
+  const view = useMemo(() => resolveInstrumentView(score, instrument), [instrument, score]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getPrintableSystems: () => innerRef.current?.getPrintableSystems() ?? [],
+    }),
+    [],
+  );
+
+  if (view.instrumentType === "DRUM") {
+    return (
+      <DrumSheet
+        audioCurrentTime={audioCurrentTime}
+        followPlayback={followPlayback}
+        isPlaying={isPlaying}
+        onFollowPlaybackChange={onFollowPlaybackChange}
+        onSeek={onSeek}
+        ref={innerRef}
+        score={view.score}
+        showLyrics={showLyrics}
+      />
+    );
+  }
+
+  return (
+    <MelodicSheet
+      audioCurrentTime={audioCurrentTime}
+      followPlayback={followPlayback}
+      isPlaying={isPlaying}
+      onFollowPlaybackChange={onFollowPlaybackChange}
+      onSeek={onSeek}
+      ref={innerRef}
+      showLyrics={showLyrics}
+      track={view.track}
+    />
+  );
+});

--- a/apps/web/components/ScoreSheet.tsx
+++ b/apps/web/components/ScoreSheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
+import { BassSheet } from "@/components/BassSheet";
 import { DrumSheet, type DrumSheetHandle, type PrintableScoreSystem } from "@/components/DrumSheet";
 import { MelodicSheet } from "@/components/MelodicSheet";
 import { resolveInstrumentView } from "@/lib/scoreTracks";
@@ -47,6 +48,21 @@ export const ScoreSheet = forwardRef<ScoreSheetHandle, Props>(function ScoreShee
         ref={innerRef}
         score={view.score}
         showLyrics={showLyrics}
+      />
+    );
+  }
+
+  if (view.instrumentType === "BASS") {
+    return (
+      <BassSheet
+        audioCurrentTime={audioCurrentTime}
+        followPlayback={followPlayback}
+        isPlaying={isPlaying}
+        onFollowPlaybackChange={onFollowPlaybackChange}
+        onSeek={onSeek}
+        ref={innerRef}
+        showLyrics={showLyrics}
+        track={view.track}
       />
     );
   }

--- a/apps/web/lib/scoreTracks.ts
+++ b/apps/web/lib/scoreTracks.ts
@@ -95,6 +95,10 @@ export type BassRenderNote = {
   lyric?: string | null;
   measure: number;
   slot: number;
+  slideDirection: "up" | "down" | null;
+  slideOutDirection: "up" | "down" | null;
+  slurFromPrevious: boolean;
+  slurToNext: boolean;
   string: 1 | 2 | 3 | 4;
   techniques: BassTechnique[];
   tieFromPrevious: boolean;
@@ -631,6 +635,8 @@ function bassSpecNoteToRenderNote(note: BassSpecNote, measure: number, slot: num
   const isDead = position.fret === "X" || techniques.includes("DEAD") || Boolean(note.is_dead);
   const stringMidi = BASS_STRING_OPEN_MIDI[position.string];
   const fallbackMidi = actualMidi ?? stringMidi;
+  const slideDirection = resolveBassSlideDirection(note);
+  const slideOutDirection = resolveBassSlideOutDirection(note);
 
   return {
     actualMidi: fallbackMidi,
@@ -646,6 +652,10 @@ function bassSpecNoteToRenderNote(note: BassSpecNote, measure: number, slot: num
     lyric: note.lyric ?? null,
     measure,
     slot,
+    slideDirection,
+    slideOutDirection,
+    slurFromPrevious: Boolean(note.slur_from_previous),
+    slurToNext: Boolean(note.slur_to_next),
     string: position.string,
     techniques,
     tieFromPrevious: Boolean(note.tie_from_previous),
@@ -671,6 +681,8 @@ function sourceEventToBassRenderNote(
   const fallbackMidi = actualMidi ?? BASS_STRING_OPEN_MIDI[position.string];
   const chord = readString(source.chord) ?? readString(source.harmony) ?? null;
   const lyric = readString(source.lyric);
+  const slideDirection = resolveBassSlideDirection(source);
+  const slideOutDirection = resolveBassSlideOutDirection(source);
 
   return {
     actualMidi: fallbackMidi,
@@ -686,6 +698,10 @@ function sourceEventToBassRenderNote(
     lyric,
     measure,
     slot,
+    slideDirection,
+    slideOutDirection,
+    slurFromPrevious: readBoolean(source.slur_from_previous),
+    slurToNext: readBoolean(source.slur_to_next),
     string: position.string,
     techniques,
     tieFromPrevious: readBoolean(source.tie_from_previous),
@@ -865,6 +881,9 @@ function normalizeBassTechnique(value: unknown): BassTechnique | null {
   }
 
   const normalized = value.trim().toUpperCase().replace(/[\s-]+/g, "_");
+  if (normalized === "/" || normalized === "\\") {
+    return "SLIDE";
+  }
   if (normalized === "H" || normalized === "HAMMER" || normalized === "HAMMER_ON" || normalized === "HAMMERON") {
     return "HAMMER_ON";
   }
@@ -883,6 +902,73 @@ function normalizeBassTechnique(value: unknown): BassTechnique | null {
   if (normalized === "POP") {
     return "POP";
   }
+  return null;
+}
+
+function resolveBassSlideDirection(source: BassSourceLike): "up" | "down" | null {
+  const explicitDirection = readBassSlideDirection(source.slide_direction);
+  if (explicitDirection) {
+    return explicitDirection;
+  }
+
+  const rawValues = [source.technique, ...(Array.isArray(source.techniques) ? source.techniques : [])];
+  for (const value of rawValues) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const normalized = value.trim().toUpperCase().replace(/[\s-]+/g, "_");
+    if (normalized === "/") {
+      return "up";
+    }
+    if (normalized === "\\") {
+      return "down";
+    }
+    if (!normalized.includes("SLIDE")) {
+      continue;
+    }
+    if (normalized.includes("DOWN") || normalized.includes("DESC")) {
+      return "down";
+    }
+    if (normalized.includes("UP") || normalized.includes("ASC") || normalized === "/") {
+      return "up";
+    }
+    if (normalized === "\\") {
+      return "down";
+    }
+  }
+
+  return null;
+}
+
+function resolveBassSlideOutDirection(source: BassSourceLike): "up" | "down" | null {
+  const explicitDirection = readBassSlideDirection(source.slide_out_direction);
+  if (explicitDirection) {
+    return explicitDirection;
+  }
+
+  const rawValues = [source.technique, ...(Array.isArray(source.techniques) ? source.techniques : [])];
+  for (const value of rawValues) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const normalized = value.trim().toUpperCase().replace(/[\s-]+/g, "_");
+    if (!normalized.includes("OUT")) {
+      continue;
+    }
+    if (normalized.includes("DOWN") || normalized.includes("DESC") || normalized === "\\") {
+      return "down";
+    }
+    if (normalized.includes("UP") || normalized.includes("ASC") || normalized === "/") {
+      return "up";
+    }
+  }
+
+  if (readBoolean(source.slide_out_to_nowhere)) {
+    return resolveBassSlideDirection(source) ?? "up";
+  }
+
   return null;
 }
 
@@ -936,12 +1022,12 @@ function bassDurationFromSlots(durationSlots: number): BassDuration {
 }
 
 function resolveBassDisplayStaffKey(staffKey: string | null, actualMidi: number): string {
-  const normalized = normalizeStaffKey(staffKey);
-  if (normalized) {
-    return normalized;
+  const transposedStaffKey = transposeStaffKeyOctaves(staffKey, 1, true);
+  if (transposedStaffKey) {
+    return transposedStaffKey;
   }
 
-  return staffKeyFromMidi(actualMidi + 12) ?? "e/3";
+  return staffKeyFromMidi(actualMidi + 12, true) ?? "e/3";
 }
 
 function slashChordBassMidi(chord: string | null, anchorMidi: number | null): number | null {
@@ -1349,6 +1435,24 @@ function readBassString(value: unknown): 1 | 2 | 3 | 4 | null {
   return null;
 }
 
+function readBassSlideDirection(value: unknown): "up" | "down" | null {
+  if (value === "up" || value === "down") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "up" || normalized === "/") {
+    return "up";
+  }
+  if (normalized === "down" || normalized === "\\") {
+    return "down";
+  }
+  return null;
+}
+
 function normalizeBassFret(value: unknown): number | "X" | null {
   if (value === "X" || value === "x") {
     return "X";
@@ -1410,14 +1514,25 @@ function normalizeStaffKey(value: string | null): string | null {
   return /^[a-g][#b]?\/-?\d+$/.test(normalized) ? normalized : null;
 }
 
-function staffKeyFromMidi(midi: number | null): string | null {
+function transposeStaffKeyOctaves(staffKey: string | null, octaves: number, preferFlats = false): string | null {
+  const midi = midiFromStaffKey(staffKey);
+  if (midi === null) {
+    return null;
+  }
+
+  return staffKeyFromMidi(midi + octaves * 12, preferFlats);
+}
+
+function staffKeyFromMidi(midi: number | null, preferFlats = false): string | null {
   if (midi === null || !Number.isFinite(midi)) {
     return null;
   }
 
-  const noteNames = ["c", "c#", "d", "d#", "e", "f", "f#", "g", "g#", "a", "a#", "b"] as const;
+  const sharpNames = ["c", "c#", "d", "d#", "e", "f", "f#", "g", "g#", "a", "a#", "b"] as const;
+  const flatNames = ["c", "db", "d", "eb", "e", "f", "gb", "g", "ab", "a", "bb", "b"] as const;
   const pitchClass = ((Math.round(midi) % 12) + 12) % 12;
   const octave = Math.floor(Math.round(midi) / 12) - 1;
+  const noteNames = preferFlats ? flatNames : sharpNames;
   return `${noteNames[pitchClass]}/${octave}`;
 }
 

--- a/apps/web/lib/scoreTracks.ts
+++ b/apps/web/lib/scoreTracks.ts
@@ -40,6 +40,17 @@ type LyricRow = {
   row: number;
 };
 
+type BassSourceLike = Partial<BassSpecNote> & {
+  chord?: string | null;
+  confidence?: number;
+  drum?: DrumNote;
+  harmony?: string | null;
+  lyric?: string | null;
+  midi_note?: number;
+  note?: DrumNote;
+  staff_key?: string | null;
+};
+
 export type MelodicNoteEvent = {
   confidence: number;
   lyric?: string | null;
@@ -298,9 +309,59 @@ function materializeDrumScore(score: AnalysisResult, track: AnalysisTrack | null
   };
 }
 
+function buildDerivedBassTrack(score: AnalysisResult): BassRenderTrack {
+  return buildBassTrackFromPayload(
+    {
+      BASS_SPEC: score.BASS_SPEC,
+      bassSpec: score.bassSpec,
+      bass_spec: score.bass_spec,
+      bpm: score.bpm,
+      engraved_measures: score.engraved_measures,
+      events: score.events,
+      midi_ticks: score.midi_ticks,
+      ticks_per_quarter: score.ticks_per_quarter,
+      words: score.words,
+    },
+    "derived",
+    score.words,
+    true,
+  );
+}
+
+function buildBassTrackFromPayload(
+  payload: TrackLikeScore | AnalysisTrack,
+  source: Exclude<TrackSource, "legacy">,
+  fallbackWords: LyricWord[],
+  useDerivedPitchMap = false,
+): BassRenderTrack {
+  const bpm = payload.bpm ?? 120;
+  const words = payload.words ?? fallbackWords;
+  const bassSpec = resolveBassSpec(payload);
+  const ticksPerQuarter = payload.ticks_per_quarter ?? 480;
+  const measures = bassSpec?.notes?.length
+    ? measuresFromBassSpec(bassSpec.notes, bpm)
+    : payload.midi_ticks?.length
+      ? bassMeasuresFromMidiTicks(payload.midi_ticks, bpm, ticksPerQuarter, useDerivedPitchMap)
+      : payload.engraved_measures?.length
+        ? bassMeasuresFromEngraved(payload.engraved_measures, bpm, ticksPerQuarter, useDerivedPitchMap)
+        : bassMeasuresFromScoreEvents(payload.events ?? [], bpm, useDerivedPitchMap);
+
+  const lyricReadyMeasures = hasAnyBassLyrics(measures) ? measures : applyBassWordsFallback(measures, words, bpm);
+
+  return {
+    bpm,
+    instrumentType: "BASS",
+    label: instrumentLabel("BASS"),
+    measures: lyricReadyMeasures.length ? lyricReadyMeasures : [{ notes: [], slots: emptyBassSlots() }],
+    mode: bassSpec?.mode ?? BASS_DEFAULT_RENDER_MODE,
+    source,
+    words,
+  };
+}
+
 function buildDerivedMelodicTrack(
   score: AnalysisResult,
-  instrument: Exclude<InstrumentType, "DRUM">,
+  instrument: Exclude<InstrumentType, "DRUM" | "BASS">,
 ): MelodicRenderTrack {
   return buildMelodicTrackFromPayload(
     {
@@ -320,7 +381,7 @@ function buildDerivedMelodicTrack(
 
 function buildMelodicTrackFromPayload(
   payload: TrackLikeScore | AnalysisTrack,
-  instrument: Exclude<InstrumentType, "DRUM">,
+  instrument: Exclude<InstrumentType, "DRUM" | "BASS">,
   source: Exclude<TrackSource, "legacy">,
   fallbackWords: LyricWord[],
   useDerivedPitchMap = false,
@@ -335,7 +396,7 @@ function buildMelodicTrackFromPayload(
 
   return {
     bpm,
-    clef: instrument === "BASS" ? "bass" : "treble",
+    clef: "treble",
     instrumentType: instrument,
     label: instrumentLabel(instrument),
     measures: hasAnyLyrics(measures) ? measures : applyWordsFallback(measures, words, bpm),
@@ -345,9 +406,678 @@ function buildMelodicTrackFromPayload(
   };
 }
 
+function measuresFromBassSpec(notes: BassSpecNote[], bpm: number): BassMeasure[] {
+  const measureMap = new Map<number, BassRenderNote[]>();
+
+  [...notes]
+    .sort((left, right) => compareBassSpecOrdering(left, right, bpm))
+    .forEach((note, index) => {
+      const measure = resolveBassMeasure(note, bpm);
+      const slot = resolveBassSlot(note, bpm);
+      const bassNote = bassSpecNoteToRenderNote(note, measure, slot, index);
+      const entries = measureMap.get(measure) ?? [];
+      entries.push(bassNote);
+      measureMap.set(measure, entries);
+    });
+
+  const measureCount = Math.max(1, Math.max(...measureMap.keys(), 1));
+  return Array.from({ length: measureCount }, (_, measureIndex) => buildBassMeasure(measureMap.get(measureIndex + 1) ?? []));
+}
+
+function bassMeasuresFromEngraved(
+  engravedMeasures: EngravedMeasure[],
+  _bpm: number,
+  ticksPerQuarter: number,
+  useDerivedPitchMap: boolean,
+): BassMeasure[] {
+  return engravedMeasures.map((measure) => {
+    const rawNotes: BassRenderNote[] = [];
+    let index = 0;
+
+    const voiceTicks = [...measure.voice1, ...measure.voice2].sort((left, right) => left.slot - right.slot);
+    for (const tick of voiceTicks) {
+      if (tick.rest || tick.events.length === 0) {
+        continue;
+      }
+
+      const sourceEvent = useDerivedPitchMap ? pickDerivedBassEvent(tick.events) : pickExplicitBassEvent(tick.events);
+      if (!sourceEvent) {
+        continue;
+      }
+
+      rawNotes.push(
+        sourceEventToBassRenderNote(
+          sourceEvent,
+          measure.measure,
+          clampSlot(tick.slot),
+          durationSlotsFromTickLike(tick.duration_ticks, ticksPerQuarter),
+          useDerivedPitchMap,
+          `bass-${measure.measure}-${tick.slot}-${index}`,
+        ),
+      );
+      index += 1;
+    }
+
+    const nextMeasure = buildBassMeasure(rawNotes);
+    for (const legacySlot of measure.slots ?? []) {
+      addBassSlotLyric(nextMeasure.slots[clampSlot(legacySlot.slot)], legacySlot.lyric ?? null, 0);
+    }
+    for (const lyricSlot of measure.lyric_slots ?? []) {
+      addBassSlotLyric(nextMeasure.slots[clampSlot(lyricSlot.slot)], lyricSlot.lyric, lyricSlot.row ?? 0);
+    }
+    return nextMeasure;
+  });
+}
+
+function bassMeasuresFromMidiTicks(
+  ticks: MidiTickEvent[],
+  _bpm: number,
+  ticksPerQuarter: number,
+  useDerivedPitchMap: boolean,
+): BassMeasure[] {
+  const grouped = new Map<number, MidiTickEvent[]>();
+  for (const tick of ticks) {
+    const measure = Math.max(1, tick.measure);
+    const entries = grouped.get(measure) ?? [];
+    entries.push(tick);
+    grouped.set(measure, entries);
+  }
+
+  const measureCount = Math.max(1, Math.max(...grouped.keys(), 1));
+  return Array.from({ length: measureCount }, (_, measureIndex) => {
+    const rawNotes = (grouped.get(measureIndex + 1) ?? []).map((tick, noteIndex) =>
+      sourceEventToBassRenderNote(
+        tick,
+        measureIndex + 1,
+        clampSlot(tick.slot),
+        durationSlotsFromTickLike(tick.duration_ticks, ticksPerQuarter),
+        useDerivedPitchMap,
+        `bass-${measureIndex + 1}-${tick.slot}-${noteIndex}`,
+      ),
+    );
+
+    return buildBassMeasure(rawNotes);
+  });
+}
+
+function bassMeasuresFromScoreEvents(
+  events: ScoreEvent[],
+  bpm: number,
+  useDerivedPitchMap: boolean,
+): BassMeasure[] {
+  const beatSeconds = 60 / Math.max(bpm || 120, 1);
+  const measureSeconds = beatSeconds * 4;
+  const grouped = new Map<number, ScoreEvent[]>();
+
+  for (const event of [...events].sort((left, right) => left.time - right.time)) {
+    const measure = Math.max(1, Math.floor(event.time / measureSeconds) + 1);
+    const entries = grouped.get(measure) ?? [];
+    entries.push(event);
+    grouped.set(measure, entries);
+  }
+
+  const measureCount = Math.max(1, Math.max(...grouped.keys(), 1));
+  return Array.from({ length: measureCount }, (_, measureIndex) => {
+    const measure = measureIndex + 1;
+    const rawNotes = (grouped.get(measure) ?? []).map((event, noteIndex) => {
+      const slot = clampSlot(Math.round((event.time - (measure - 1) * measureSeconds) / (beatSeconds / 4)));
+      return sourceEventToBassRenderNote(event, measure, slot, 4, useDerivedPitchMap, `bass-${measure}-${slot}-${noteIndex}`);
+    });
+
+    return buildBassMeasure(rawNotes);
+  });
+}
+
+function buildBassMeasure(rawNotes: BassRenderNote[]): BassMeasure {
+  const slots = emptyBassSlots();
+  const prioritizedNotes = prioritizeBassNotes(rawNotes);
+
+  for (const note of prioritizedNotes) {
+    slots[clampSlot(note.slot)].notes.push(note);
+    addBassSlotLyric(slots[clampSlot(note.slot)], note.lyric ?? null, 0);
+  }
+
+  return {
+    notes: prioritizedNotes,
+    slots,
+  };
+}
+
+function prioritizeBassNotes(notes: BassRenderNote[]): BassRenderNote[] {
+  const grouped = new Map<number, BassRenderNote[]>();
+  for (const note of notes) {
+    const entries = grouped.get(note.slot) ?? [];
+    entries.push(note);
+    grouped.set(note.slot, entries);
+  }
+
+  return Array.from(grouped.entries())
+    .map(([, sameSlotNotes]) =>
+      [...sameSlotNotes].sort((left, right) => compareBassRenderPriority(left, right))[0],
+    )
+    .sort((left, right) => left.measure - right.measure || left.slot - right.slot);
+}
+
+function compareBassRenderPriority(left: BassRenderNote, right: BassRenderNote): number {
+  const leftChordSlash = hasSlashChord(left.chord);
+  const rightChordSlash = hasSlashChord(right.chord);
+  if (leftChordSlash !== rightChordSlash) {
+    return leftChordSlash ? -1 : 1;
+  }
+
+  if (left.isDead !== right.isDead) {
+    return left.isDead ? 1 : -1;
+  }
+
+  const leftMidi = left.actualMidi ?? Number.POSITIVE_INFINITY;
+  const rightMidi = right.actualMidi ?? Number.POSITIVE_INFINITY;
+  if (leftMidi !== rightMidi) {
+    return leftMidi - rightMidi;
+  }
+
+  if (left.string !== right.string) {
+    return right.string - left.string;
+  }
+
+  return left.fret === "X" || right.fret === "X" ? 0 : left.fret - right.fret;
+}
+
+function compareBassSpecOrdering(left: BassSpecNote, right: BassSpecNote, bpm: number): number {
+  const leftMeasure = resolveBassMeasure(left, bpm);
+  const rightMeasure = resolveBassMeasure(right, bpm);
+  if (leftMeasure !== rightMeasure) {
+    return leftMeasure - rightMeasure;
+  }
+
+  const leftSlot = resolveBassSlot(left, bpm);
+  const rightSlot = resolveBassSlot(right, bpm);
+  return leftSlot - rightSlot;
+}
+
+function resolveBassMeasure(note: Pick<BassSpecNote, "measure" | "time">, bpm: number): number {
+  if (note.measure && Number.isFinite(note.measure)) {
+    return Math.max(1, Math.round(note.measure));
+  }
+
+  if (note.time !== undefined && Number.isFinite(note.time)) {
+    const beatSeconds = 60 / Math.max(bpm || 120, 1);
+    return Math.max(1, Math.floor(note.time / (beatSeconds * 4)) + 1);
+  }
+
+  return 1;
+}
+
+function resolveBassSlot(note: Pick<BassSpecNote, "measure" | "slot" | "time">, bpm: number): number {
+  if (note.slot !== undefined && Number.isFinite(note.slot)) {
+    return clampSlot(Math.round(note.slot));
+  }
+
+  if (note.time !== undefined && Number.isFinite(note.time)) {
+    const beatSeconds = 60 / Math.max(bpm || 120, 1);
+    const measureSeconds = beatSeconds * 4;
+    const localMeasure = Math.floor(note.time / measureSeconds);
+    const measureStart = localMeasure * measureSeconds;
+    return clampSlot(Math.floor((note.time - measureStart) / (measureSeconds / SLOTS_PER_MEASURE)));
+  }
+
+  return 0;
+}
+
+function bassSpecNoteToRenderNote(note: BassSpecNote, measure: number, slot: number, index: number): BassRenderNote {
+  const techniques = normalizeBassTechniques(note);
+  const actualMidi = resolveBassActualMidi(note, techniques);
+  const position = resolveBassPosition(note, actualMidi);
+  const durationSlots = resolveBassDurationSlots(note.duration, note.duration_slots);
+  const isDead = position.fret === "X" || techniques.includes("DEAD") || Boolean(note.is_dead);
+  const stringMidi = BASS_STRING_OPEN_MIDI[position.string];
+  const fallbackMidi = actualMidi ?? stringMidi;
+
+  return {
+    actualMidi: fallbackMidi,
+    chord: note.chord ?? note.harmony ?? null,
+    confidence: note.confidence ?? 1,
+    displayStaffKey: resolveBassDisplayStaffKey(note.staff_key ?? null, fallbackMidi),
+    duration: bassDurationFromSlots(durationSlots),
+    durationSlots,
+    fret: isDead ? "X" : position.fret,
+    id: note.id ?? `bass-${measure}-${slot}-${index}`,
+    isDead,
+    isStaccato: Boolean(note.is_staccato),
+    lyric: note.lyric ?? null,
+    measure,
+    slot,
+    string: position.string,
+    techniques,
+    tieFromPrevious: Boolean(note.tie_from_previous),
+    tieToNext: Boolean(note.tie_to_next),
+  };
+}
+
+function sourceEventToBassRenderNote(
+  source: BassSourceLike,
+  measure: number,
+  slot: number,
+  rawDurationSlots: number,
+  useDerivedPitchMap: boolean,
+  id: string,
+): BassRenderNote {
+  const derivedDrum = (source.drum ?? source.note) ?? null;
+  const techniques = normalizeBassTechniques(source);
+  const actualMidi = useDerivedPitchMap
+    ? (derivedDrum ? BASS_DERIVED_ACTUAL_MIDI[derivedDrum] : null)
+    : resolveBassActualMidi(source, techniques);
+  const position = resolveBassPosition(source, actualMidi);
+  const durationSlots = enforceBassDurationSlots(rawDurationSlots);
+  const fallbackMidi = actualMidi ?? BASS_STRING_OPEN_MIDI[position.string];
+  const chord = readString(source.chord) ?? readString(source.harmony) ?? null;
+  const lyric = readString(source.lyric);
+
+  return {
+    actualMidi: fallbackMidi,
+    chord,
+    confidence: readNumber(source.confidence) ?? 1,
+    displayStaffKey: resolveBassDisplayStaffKey(readString(source.staff_key), fallbackMidi),
+    duration: bassDurationFromSlots(durationSlots),
+    durationSlots,
+    fret: position.fret,
+    id,
+    isDead: position.fret === "X" || techniques.includes("DEAD") || readBoolean(source.is_dead),
+    isStaccato: readBoolean(source.is_staccato),
+    lyric,
+    measure,
+    slot,
+    string: position.string,
+    techniques,
+    tieFromPrevious: readBoolean(source.tie_from_previous),
+    tieToNext: readBoolean(source.tie_to_next),
+  };
+}
+
+function pickDerivedBassEvent(events: BassSourceLike[]): BassSourceLike | null {
+  return (
+    [...events].sort((left, right) => {
+      const leftDrum = left.drum ?? left.note;
+      const rightDrum = right.drum ?? right.note;
+      const leftMidi = leftDrum ? BASS_DERIVED_ACTUAL_MIDI[leftDrum] : Number.POSITIVE_INFINITY;
+      const rightMidi = rightDrum ? BASS_DERIVED_ACTUAL_MIDI[rightDrum] : Number.POSITIVE_INFINITY;
+      return leftMidi - rightMidi;
+    })[0] ?? null
+  );
+}
+
+function pickExplicitBassEvent(events: BassSourceLike[]): BassSourceLike | null {
+  return (
+    [...events].sort((left, right) => {
+      const leftMidi = resolveBassActualMidi(left, normalizeBassTechniques(left)) ?? Number.POSITIVE_INFINITY;
+      const rightMidi = resolveBassActualMidi(right, normalizeBassTechniques(right)) ?? Number.POSITIVE_INFINITY;
+      return leftMidi - rightMidi;
+    })[0] ?? null
+  );
+}
+
+function resolveBassActualMidi(
+  source: BassSourceLike,
+  techniques: BassTechnique[],
+): number | null {
+  const explicitString = readBassString(source.string) ?? readBassString(source.prefer_string);
+  const explicitFret = normalizeBassFret(source.fret);
+  if (explicitString && typeof explicitFret === "number") {
+    return BASS_STRING_OPEN_MIDI[explicitString] + explicitFret;
+  }
+
+  let midi = readNumber(source.midi_note);
+  const slashMidi = slashChordBassMidi(readString(source.chord) ?? readString(source.harmony), midi);
+  if (slashMidi !== null) {
+    midi = slashMidi;
+  }
+
+  if (midi === null) {
+    const displayMidi = midiFromStaffKey(readString(source.staff_key));
+    if (displayMidi !== null) {
+      midi = displayMidi - 12;
+    }
+  }
+
+  if (midi === null && explicitString) {
+    return BASS_STRING_OPEN_MIDI[explicitString];
+  }
+
+  if (techniques.includes("DEAD") && explicitString) {
+    return BASS_STRING_OPEN_MIDI[explicitString];
+  }
+
+  return midi;
+}
+
+function resolveBassPosition(
+  source: BassSourceLike,
+  actualMidi: number | null,
+): { fret: number | "X"; string: 1 | 2 | 3 | 4 } {
+  const explicitString = readBassString(source.string);
+  const preferredString = readBassString(source.prefer_string);
+  const explicitFret = normalizeBassFret(source.fret);
+  const deadRequested = explicitFret === "X" || readBoolean(source.is_dead);
+
+  if (explicitString && explicitFret !== null) {
+    return { fret: deadRequested ? "X" : explicitFret, string: explicitString };
+  }
+
+  if (explicitString && actualMidi !== null) {
+    const fret = Math.round(actualMidi - BASS_STRING_OPEN_MIDI[explicitString]);
+    if (fret >= BASS_FRET_MIN && fret <= BASS_FRET_MAX) {
+      return { fret: deadRequested ? "X" : fret, string: explicitString };
+    }
+  }
+
+  if (actualMidi !== null) {
+    const candidate = chooseBassPosition(actualMidi, preferredString ?? explicitString ?? undefined);
+    if (candidate) {
+      return { fret: deadRequested ? "X" : candidate.fret, string: candidate.string };
+    }
+  }
+
+  return { fret: deadRequested ? "X" : 0, string: preferredString ?? explicitString ?? 4 };
+}
+
+function chooseBassPosition(
+  actualMidi: number,
+  preferredString?: 1 | 2 | 3 | 4,
+): { fret: number; string: 1 | 2 | 3 | 4 } | null {
+  const roundedMidi = Math.round(actualMidi);
+  const candidates: Array<{ fret: number; octaveShift: number; string: 1 | 2 | 3 | 4 }> = [];
+
+  for (const string of [1, 2, 3, 4] as const) {
+    const fret = roundedMidi - BASS_STRING_OPEN_MIDI[string];
+    if (fret >= BASS_FRET_MIN && fret <= BASS_FRET_MAX) {
+      candidates.push({ fret, octaveShift: 0, string });
+    }
+  }
+
+  for (const shift of [-12, 12, -24, 24]) {
+    for (const string of [1, 2, 3, 4] as const) {
+      const fret = roundedMidi + shift - BASS_STRING_OPEN_MIDI[string];
+      if (fret >= BASS_FRET_MIN && fret <= BASS_FRET_MAX) {
+        candidates.push({ fret, octaveShift: Math.abs(shift), string });
+      }
+    }
+  }
+
+  if (!candidates.length) {
+    return null;
+  }
+
+  candidates.sort((left, right) => {
+    if (preferredString && left.string !== right.string) {
+      if (left.string === preferredString) {
+        return -1;
+      }
+      if (right.string === preferredString) {
+        return 1;
+      }
+    }
+
+    if (left.octaveShift !== right.octaveShift) {
+      return left.octaveShift - right.octaveShift;
+    }
+    if (left.fret !== right.fret) {
+      return left.fret - right.fret;
+    }
+    return left.string - right.string;
+  });
+
+  return candidates[0];
+}
+
+function normalizeBassTechniques(source: BassSourceLike): BassTechnique[] {
+  const techniques = new Set<BassTechnique>();
+
+  const rawValues = [
+    source.technique,
+    ...(Array.isArray(source.techniques) ? source.techniques : []),
+  ];
+
+  rawValues.forEach((value) => {
+    const normalized = normalizeBassTechnique(value);
+    if (normalized) {
+      techniques.add(normalized);
+    }
+  });
+
+  if (readBoolean(source.is_dead)) {
+    techniques.add("DEAD");
+  }
+  if (readBoolean(source.slap_style)) {
+    techniques.add("SLAP");
+  }
+  if (readBoolean(source.is_pop)) {
+    techniques.add("POP");
+  }
+  if (readBoolean(source.is_pull_off)) {
+    techniques.add("PULL_OFF");
+  }
+
+  return Array.from(techniques);
+}
+
+function normalizeBassTechnique(value: unknown): BassTechnique | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toUpperCase().replace(/[\s-]+/g, "_");
+  if (normalized === "H" || normalized === "HAMMER" || normalized === "HAMMER_ON" || normalized === "HAMMERON") {
+    return "HAMMER_ON";
+  }
+  if (normalized === "PULL" || normalized === "PULLOFF" || normalized === "PULL_OFF") {
+    return "PULL_OFF";
+  }
+  if (normalized === "S" || normalized === "SLIDE") {
+    return "SLIDE";
+  }
+  if (normalized === "X" || normalized === "DEAD" || normalized === "MUTED" || normalized === "MUTE") {
+    return "DEAD";
+  }
+  if (normalized === "T" || normalized === "THUMB" || normalized === "SLAP") {
+    return "SLAP";
+  }
+  if (normalized === "POP") {
+    return "POP";
+  }
+  return null;
+}
+
+function resolveBassDurationSlots(duration?: BassDuration, durationSlots?: number): number {
+  if (durationSlots !== undefined && Number.isFinite(durationSlots)) {
+    return enforceBassDurationSlots(durationSlots);
+  }
+
+  switch (duration) {
+    case "w":
+      return 16;
+    case "h":
+      return 8;
+    case "q":
+      return 4;
+    case "8":
+      return 2;
+    case "16":
+      return 1;
+    default:
+      return 4;
+  }
+}
+
+function durationSlotsFromTickLike(durationTicks: number, ticksPerQuarter: number): number {
+  const slotTicks = Math.max(1, Math.round(ticksPerQuarter / 4));
+  return enforceBassDurationSlots(Math.max(1, Math.round(durationTicks / slotTicks)));
+}
+
+function enforceBassDurationSlots(value: number): number {
+  const rounded = Math.max(1, Math.round(value));
+  const supported = [16, 8, 4, 2, 1];
+  return supported.reduce((closest, candidate) =>
+    Math.abs(candidate - rounded) < Math.abs(closest - rounded) ? candidate : closest,
+  );
+}
+
+function bassDurationFromSlots(durationSlots: number): BassDuration {
+  switch (enforceBassDurationSlots(durationSlots)) {
+    case 16:
+      return "w";
+    case 8:
+      return "h";
+    case 4:
+      return "q";
+    case 2:
+      return "8";
+    default:
+      return "16";
+  }
+}
+
+function resolveBassDisplayStaffKey(staffKey: string | null, actualMidi: number): string {
+  const normalized = normalizeStaffKey(staffKey);
+  if (normalized) {
+    return normalized;
+  }
+
+  return staffKeyFromMidi(actualMidi + 12) ?? "e/3";
+}
+
+function slashChordBassMidi(chord: string | null, anchorMidi: number | null): number | null {
+  const bassToken = chord?.split("/")[1]?.trim();
+  if (!bassToken) {
+    return null;
+  }
+
+  const pitchClass = pitchClassFromToken(bassToken);
+  if (pitchClass === null) {
+    return null;
+  }
+
+  const minimumMidi = BASS_STRING_OPEN_MIDI[4];
+  const maximumMidi = BASS_STRING_OPEN_MIDI[1] + BASS_FRET_MAX;
+  const anchor = anchorMidi ?? minimumMidi + 7;
+  let best: number | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (let octave = 0; octave <= 8; octave += 1) {
+    const midi = pitchClass + octave * 12;
+    if (midi < minimumMidi || midi > maximumMidi) {
+      continue;
+    }
+    const distance = Math.abs(midi - anchor);
+    if (distance < bestDistance || (distance === bestDistance && best !== null && midi < best)) {
+      best = midi;
+      bestDistance = distance;
+    }
+  }
+
+  return best;
+}
+
+function pitchClassFromToken(token: string): number | null {
+  const normalized = token.trim().toUpperCase().replace(/[^A-G#B]/g, "");
+  const note = normalized.slice(0, 2).endsWith("#") || normalized.slice(0, 2).endsWith("B")
+    ? normalized.slice(0, 2)
+    : normalized.slice(0, 1);
+
+  const pitchClasses: Record<string, number> = {
+    A: 9,
+    "A#": 10,
+    AB: 8,
+    B: 11,
+    BB: 10,
+    C: 0,
+    "C#": 1,
+    CB: 11,
+    D: 2,
+    "D#": 3,
+    DB: 1,
+    E: 4,
+    EB: 3,
+    F: 5,
+    "F#": 6,
+    FB: 4,
+    G: 7,
+    "G#": 8,
+    GB: 6,
+  };
+
+  return pitchClasses[note] ?? null;
+}
+
+function emptyBassSlots(): BassSlot[] {
+  return Array.from({ length: SLOTS_PER_MEASURE }, () => ({
+    lyric: null,
+    lyrics: [],
+    notes: [],
+  }));
+}
+
+function hasAnyBassLyrics(measures: BassMeasure[]): boolean {
+  return measures.some((measure) =>
+    measure.slots.some((slot) => Boolean(slot.lyric?.trim()) || slot.lyrics.some((entry) => Boolean(entry.lyric.trim()))),
+  );
+}
+
+function applyBassWordsFallback(measures: BassMeasure[], words: LyricWord[], bpm: number): BassMeasure[] {
+  if (!words.length) {
+    return measures.length ? measures : [{ notes: [], slots: emptyBassSlots() }];
+  }
+
+  const beatSeconds = 60 / Math.max(bpm || 120, 1);
+  const measureSeconds = beatSeconds * 4;
+  const slotSeconds = measureSeconds / SLOTS_PER_MEASURE;
+
+  for (const word of words) {
+    const measureIndex = Math.max(0, Math.floor(word.start / measureSeconds));
+    const measure = ensureBassMeasure(measures, measureIndex);
+    const measureStart = measureIndex * measureSeconds;
+    const slotIndex = Math.min(
+      SLOTS_PER_MEASURE - 1,
+      Math.max(0, Math.floor((word.start - measureStart) / slotSeconds)),
+    );
+    const targetSlot = firstAvailableBassLyricSlot(measure.slots, slotIndex);
+    if (targetSlot !== null) {
+      addBassSlotLyric(measure.slots[targetSlot], word.word.trim().normalize("NFC"), 0);
+    }
+  }
+
+  return measures;
+}
+
+function ensureBassMeasure(measures: BassMeasure[], measureIndex: number): BassMeasure {
+  while (measures.length <= measureIndex) {
+    measures.push({ notes: [], slots: emptyBassSlots() });
+  }
+  return measures[measureIndex];
+}
+
+function firstAvailableBassLyricSlot(slots: BassSlot[], preferredSlot: number): number | null {
+  for (let slot = preferredSlot; slot < SLOTS_PER_MEASURE; slot += 1) {
+    if (!slots[slot].lyric?.trim() && slots[slot].lyrics.length === 0) {
+      return slot;
+    }
+  }
+  return null;
+}
+
+function addBassSlotLyric(slot: BassSlot, next: string | null | undefined, row: number) {
+  const cleanNext = next?.trim().normalize("NFC");
+  if (!cleanNext) {
+    return;
+  }
+
+  const cleanRow = Math.max(0, row);
+  slot.lyrics.push({ lyric: cleanNext, row: cleanRow });
+  slot.lyrics.sort((left, right) => left.row - right.row);
+  slot.lyric = mergeLyric(slot.lyric, cleanNext);
+}
+
 function measuresFromEngraved(
   engravedMeasures: EngravedMeasure[],
-  instrument: Exclude<InstrumentType, "DRUM">,
+  instrument: Exclude<InstrumentType, "DRUM" | "BASS">,
   useDerivedPitchMap: boolean,
 ): MelodicMeasure[] {
   return engravedMeasures.map((measure) => {
@@ -382,7 +1112,7 @@ function measuresFromEngraved(
 
 function measuresFromMidiTicks(
   ticks: MidiTickEvent[],
-  instrument: Exclude<InstrumentType, "DRUM">,
+  instrument: Exclude<InstrumentType, "DRUM" | "BASS">,
   useDerivedPitchMap: boolean,
 ): MelodicMeasure[] {
   const grouped = new Map<number, MidiTickEvent[]>();
@@ -414,7 +1144,7 @@ function measuresFromMidiTicks(
 function measuresFromScoreEvents(
   events: ScoreEvent[],
   bpm: number,
-  instrument: Exclude<InstrumentType, "DRUM">,
+  instrument: Exclude<InstrumentType, "DRUM" | "BASS">,
   useDerivedPitchMap: boolean,
 ): MelodicMeasure[] {
   const beatSeconds = 60 / Math.max(bpm || 120, 1);
@@ -453,7 +1183,7 @@ function measuresFromScoreEvents(
 function melodicEventFromAnySource(
   event: { confidence?: number; lyric?: string | null; midi_note?: number; staff_key?: string | null },
   voice: VoiceNumber,
-  instrument: Exclude<InstrumentType, "DRUM">,
+  instrument: Exclude<InstrumentType, "DRUM" | "BASS">,
 ): MelodicNoteEvent | null {
   const normalizedKey = normalizeStaffKey(event.staff_key ?? null);
   const staffKey = normalizedKey ?? staffKeyFromMidi(event.midi_note ?? null) ?? fallbackStaffKeyForInstrument(instrument, voice);
@@ -473,7 +1203,7 @@ function melodicEventFromAnySource(
 function melodicEventFromDrumLike(
   event: { confidence?: number; drum?: DrumNote; lyric?: string | null },
   voice: VoiceNumber,
-  instrument: Exclude<InstrumentType, "DRUM">,
+  instrument: Exclude<InstrumentType, "DRUM" | "BASS">,
 ): MelodicNoteEvent | null {
   if (!event.drum) {
     return null;
@@ -596,6 +1326,73 @@ function resolveInstrumentType(value: SourceTagged | null | undefined): Instrume
   return value?.instrumentType ?? value?.instrument_type ?? null;
 }
 
+function resolveBassSpec(value: SourceTagged | null | undefined): BassSpec | null {
+  return value?.bassSpec ?? value?.bass_spec ?? value?.BASS_SPEC ?? null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function readBassString(value: unknown): 1 | 2 | 3 | 4 | null {
+  if (value === 1 || value === 2 || value === 3 || value === 4) {
+    return value;
+  }
+  return null;
+}
+
+function normalizeBassFret(value: unknown): number | "X" | null {
+  if (value === "X" || value === "x") {
+    return "X";
+  }
+
+  if (typeof value === "string" && value.trim() === "0") {
+    return 0;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(BASS_FRET_MIN, Math.min(BASS_FRET_MAX, Math.round(value)));
+  }
+
+  return null;
+}
+
+function midiFromStaffKey(staffKey: string | null): number | null {
+  const normalized = normalizeStaffKey(staffKey);
+  if (!normalized) {
+    return null;
+  }
+
+  const match = /^([a-g])([#b]?)[/](-?\d+)$/.exec(normalized);
+  if (!match) {
+    return null;
+  }
+
+  const noteToSemitone: Record<string, number> = {
+    a: 9,
+    b: 11,
+    c: 0,
+    d: 2,
+    e: 4,
+    f: 5,
+    g: 7,
+  };
+  const accidental = match[2] === "#" ? 1 : match[2] === "b" ? -1 : 0;
+  return (Number(match[3]) + 1) * 12 + noteToSemitone[match[1]] + accidental;
+}
+
+function hasSlashChord(chord: string | null | undefined): boolean {
+  return Boolean(chord && chord.includes("/"));
+}
+
 function countMeasuresFromTicks(ticks: MidiTickEvent[]): number {
   return Math.max(1, Math.max(...ticks.map((tick) => tick.measure), 1));
 }
@@ -625,14 +1422,11 @@ function staffKeyFromMidi(midi: number | null): string | null {
 }
 
 function fallbackStaffKeyForInstrument(
-  instrument: Exclude<InstrumentType, "DRUM">,
+  instrument: Exclude<InstrumentType, "DRUM" | "BASS">,
   voice: VoiceNumber,
 ): string {
   if (instrument === "KEYBOARD") {
     return voice === 1 ? "c/5" : "c/3";
-  }
-  if (instrument === "BASS") {
-    return "e/2";
   }
   return "e/4";
 }

--- a/apps/web/lib/scoreTracks.ts
+++ b/apps/web/lib/scoreTracks.ts
@@ -1,0 +1,657 @@
+"use client";
+
+import type {
+  AnalysisResult,
+  AnalysisTrack,
+  BassDuration,
+  BassRenderMode,
+  BassSpec,
+  BassSpecNote,
+  BassTechnique,
+  DrumNote,
+  EngravedMeasure,
+  InstrumentNotation,
+  InstrumentType,
+  LyricWord,
+  MidiTickEvent,
+  ScoreEvent,
+} from "./types";
+
+type VoiceNumber = 1 | 2;
+
+type TrackSource = "explicit" | "derived" | "legacy";
+
+type TrackLikeScore = Pick<AnalysisResult, "bpm" | "engraved_measures" | "events" | "midi_ticks" | "ticks_per_quarter" | "words"> & {
+  BASS_SPEC?: BassSpec;
+  bassSpec?: BassSpec;
+  bass_spec?: BassSpec;
+};
+
+type SourceTagged = {
+  BASS_SPEC?: BassSpec;
+  bassSpec?: BassSpec;
+  bass_spec?: BassSpec;
+  instrumentType?: InstrumentType;
+  instrument_type?: InstrumentType;
+};
+
+type LyricRow = {
+  lyric: string;
+  row: number;
+};
+
+export type MelodicNoteEvent = {
+  confidence: number;
+  lyric?: string | null;
+  midiNote: number | null;
+  staffKey: string;
+  voice: VoiceNumber;
+};
+
+export type MelodicSlot = {
+  lyric?: string | null;
+  lyrics: LyricRow[];
+  voice1: MelodicNoteEvent[];
+  voice2: MelodicNoteEvent[];
+};
+
+export type MelodicMeasure = {
+  slots: MelodicSlot[];
+};
+
+export type MelodicRenderTrack = {
+  bpm: number;
+  clef: "bass" | "treble";
+  instrumentType: Exclude<InstrumentType, "DRUM" | "BASS">;
+  label: string;
+  measures: MelodicMeasure[];
+  notation: Exclude<InstrumentNotation, "percussion">;
+  source: Exclude<TrackSource, "legacy">;
+  words: LyricWord[];
+};
+
+export type BassRenderNote = {
+  actualMidi: number | null;
+  chord?: string | null;
+  confidence: number;
+  displayStaffKey: string;
+  duration: Exclude<BassDuration, "w" | "h"> | "w" | "h";
+  durationSlots: number;
+  fret: number | "X";
+  id: string;
+  isDead: boolean;
+  isStaccato: boolean;
+  lyric?: string | null;
+  measure: number;
+  slot: number;
+  string: 1 | 2 | 3 | 4;
+  techniques: BassTechnique[];
+  tieFromPrevious: boolean;
+  tieToNext: boolean;
+};
+
+export type BassSlot = {
+  lyric?: string | null;
+  lyrics: LyricRow[];
+  notes: BassRenderNote[];
+};
+
+export type BassMeasure = {
+  notes: BassRenderNote[];
+  slots: BassSlot[];
+};
+
+export type BassRenderTrack = {
+  bpm: number;
+  instrumentType: "BASS";
+  label: string;
+  measures: BassMeasure[];
+  mode: BassRenderMode;
+  source: Exclude<TrackSource, "legacy">;
+  words: LyricWord[];
+};
+
+export type ResolvedInstrumentView =
+  | {
+      instrumentType: "DRUM";
+      label: string;
+      score: AnalysisResult;
+      source: Extract<TrackSource, "explicit" | "legacy">;
+    }
+  | {
+      instrumentType: "BASS";
+      label: string;
+      source: Exclude<TrackSource, "legacy">;
+      track: BassRenderTrack;
+    }
+  | {
+      instrumentType: Exclude<InstrumentType, "DRUM" | "BASS">;
+      label: string;
+      source: Exclude<TrackSource, "legacy">;
+      track: MelodicRenderTrack;
+    };
+
+export const INSTRUMENT_OPTIONS: Array<{ icon: string; instrument: InstrumentType; label: string }> = [
+  { icon: "🥁", instrument: "DRUM", label: "Drum" },
+  { icon: "🎸", instrument: "BASS", label: "Bass" },
+  { icon: "🎸", instrument: "GUITAR", label: "Guitar" },
+  { icon: "🎹", instrument: "KEYBOARD", label: "Keyboard" },
+];
+
+const SLOTS_PER_MEASURE = 16;
+const BASS_STRING_OPEN_MIDI: Record<1 | 2 | 3 | 4, number> = {
+  1: 43,
+  2: 38,
+  3: 33,
+  4: 28,
+};
+const BASS_FRET_MIN = 0;
+const BASS_FRET_MAX = 24;
+const BASS_DEFAULT_RENDER_MODE: BassRenderMode = "both";
+const BASS_DERIVED_ACTUAL_MIDI: Record<DrumNote, number> = {
+  crash: 43,
+  hihat_closed: 38,
+  hihat_open: 40,
+  kick: 28,
+  ride: 35,
+  snare: 33,
+  tom: 36,
+};
+
+const DERIVED_SINGLE_STAFF_PITCHES: Record<Exclude<InstrumentType, "DRUM" | "KEYBOARD">, Record<DrumNote, string>> = {
+  BASS: {
+    crash: "f/3",
+    hihat_closed: "g/2",
+    hihat_open: "a/2",
+    kick: "e/2",
+    ride: "d/3",
+    snare: "a/2",
+    tom: "c/3",
+  },
+  GUITAR: {
+    crash: "f/5",
+    hihat_closed: "g/4",
+    hihat_open: "a/4",
+    kick: "e/4",
+    ride: "d/5",
+    snare: "a/4",
+    tom: "c/5",
+  },
+};
+
+const DERIVED_KEYBOARD_PITCHES: Record<VoiceNumber, Record<DrumNote, string>> = {
+  1: {
+    crash: "e/5",
+    hihat_closed: "g/5",
+    hihat_open: "a/5",
+    kick: "c/5",
+    ride: "d/5",
+    snare: "b/4",
+    tom: "g/4",
+  },
+  2: {
+    crash: "c/3",
+    hihat_closed: "g/2",
+    hihat_open: "a/2",
+    kick: "e/2",
+    ride: "d/3",
+    snare: "c/3",
+    tom: "g/2",
+  },
+};
+
+export function resolveInstrumentView(score: AnalysisResult, instrument: InstrumentType): ResolvedInstrumentView {
+  const label = instrumentLabel(instrument);
+  const explicitTrack = findTrack(score, instrument);
+
+  if (instrument === "DRUM") {
+    return {
+      instrumentType: "DRUM",
+      label,
+      score: materializeDrumScore(score, explicitTrack),
+      source: explicitTrack ? "explicit" : "legacy",
+    };
+  }
+
+  if (instrument === "BASS") {
+    if (explicitTrack) {
+      return {
+        instrumentType: "BASS",
+        label,
+        source: "explicit",
+        track: buildBassTrackFromPayload(explicitTrack, "explicit", score.words),
+      };
+    }
+
+    return {
+      instrumentType: "BASS",
+      label,
+      source: "derived",
+      track: buildDerivedBassTrack(score),
+    };
+  }
+
+  if (explicitTrack) {
+    return {
+      instrumentType: instrument,
+      label,
+      source: "explicit",
+      track: buildMelodicTrackFromPayload(explicitTrack, instrument, "explicit", score.words),
+    };
+  }
+
+  return {
+    instrumentType: instrument,
+    label,
+    source: "derived",
+    track: buildDerivedMelodicTrack(score, instrument),
+  };
+}
+
+export function instrumentLabel(instrument: InstrumentType): string {
+  return INSTRUMENT_OPTIONS.find((option) => option.instrument === instrument)?.label ?? instrument;
+}
+
+export function resolvedViewMeasureCount(view: ResolvedInstrumentView): number {
+  if (view.instrumentType === "DRUM") {
+    return Math.max(1, view.score.engraved_measures.length || countMeasuresFromTicks(view.score.midi_ticks));
+  }
+
+  return view.track.measures.length;
+}
+
+export function resolvedViewNoteCount(view: ResolvedInstrumentView): number {
+  if (view.instrumentType === "DRUM") {
+    return view.score.midi_ticks.length || view.score.events.length;
+  }
+
+  if (view.instrumentType === "BASS") {
+    return view.track.measures.reduce((total, measure) => total + measure.notes.length, 0);
+  }
+
+  return view.track.measures.reduce(
+    (total, measure) =>
+      total + measure.slots.reduce((slotTotal, slot) => slotTotal + slot.voice1.length + slot.voice2.length, 0),
+    0,
+  );
+}
+
+function findTrack(score: AnalysisResult, instrument: InstrumentType): AnalysisTrack | null {
+  return score.tracks?.find((track) => resolveInstrumentType(track) === instrument) ?? null;
+}
+
+function materializeDrumScore(score: AnalysisResult, track: AnalysisTrack | null): AnalysisResult {
+  if (!track) {
+    return score;
+  }
+
+  return {
+    bpm: track.bpm ?? score.bpm,
+    engraved_measures: track.engraved_measures ?? [],
+    events: track.events ?? [],
+    instrumentType: "DRUM",
+    instrument_type: "DRUM",
+    midi_ticks: track.midi_ticks ?? [],
+    ticks_per_quarter: track.ticks_per_quarter ?? score.ticks_per_quarter,
+    tracks: score.tracks,
+    words: track.words ?? score.words,
+  };
+}
+
+function buildDerivedMelodicTrack(
+  score: AnalysisResult,
+  instrument: Exclude<InstrumentType, "DRUM">,
+): MelodicRenderTrack {
+  return buildMelodicTrackFromPayload(
+    {
+      bpm: score.bpm,
+      engraved_measures: score.engraved_measures,
+      events: score.events,
+      midi_ticks: score.midi_ticks,
+      ticks_per_quarter: score.ticks_per_quarter,
+      words: score.words,
+    },
+    instrument,
+    "derived",
+    score.words,
+    true,
+  );
+}
+
+function buildMelodicTrackFromPayload(
+  payload: TrackLikeScore | AnalysisTrack,
+  instrument: Exclude<InstrumentType, "DRUM">,
+  source: Exclude<TrackSource, "legacy">,
+  fallbackWords: LyricWord[],
+  useDerivedPitchMap = false,
+): MelodicRenderTrack {
+  const bpm = payload.bpm ?? 120;
+  const words = payload.words ?? fallbackWords;
+  const measures = payload.engraved_measures?.length
+    ? measuresFromEngraved(payload.engraved_measures, instrument, useDerivedPitchMap)
+    : payload.midi_ticks?.length
+      ? measuresFromMidiTicks(payload.midi_ticks, instrument, useDerivedPitchMap)
+      : measuresFromScoreEvents(payload.events ?? [], bpm, instrument, useDerivedPitchMap);
+
+  return {
+    bpm,
+    clef: instrument === "BASS" ? "bass" : "treble",
+    instrumentType: instrument,
+    label: instrumentLabel(instrument),
+    measures: hasAnyLyrics(measures) ? measures : applyWordsFallback(measures, words, bpm),
+    notation: instrument === "KEYBOARD" ? "grand" : "staff",
+    source,
+    words,
+  };
+}
+
+function measuresFromEngraved(
+  engravedMeasures: EngravedMeasure[],
+  instrument: Exclude<InstrumentType, "DRUM">,
+  useDerivedPitchMap: boolean,
+): MelodicMeasure[] {
+  return engravedMeasures.map((measure) => {
+    const slots = emptyMelodicSlots();
+
+    for (const legacySlot of measure.slots ?? []) {
+      addSlotLyric(slots[clampSlot(legacySlot.slot)], legacySlot.lyric ?? null, 0);
+    }
+
+    for (const lyricSlot of measure.lyric_slots ?? []) {
+      addSlotLyric(slots[clampSlot(lyricSlot.slot)], lyricSlot.lyric, lyricSlot.row ?? 0);
+    }
+
+    const voiceTicks = [...measure.voice1, ...measure.voice2].sort((left, right) => left.slot - right.slot);
+    for (const tick of voiceTicks) {
+      const slot = slots[clampSlot(tick.slot)];
+      for (const event of tick.events) {
+        const melodicEvent = useDerivedPitchMap
+          ? melodicEventFromDrumLike(event, tick.voice, instrument)
+          : melodicEventFromAnySource(event, tick.voice, instrument);
+        if (melodicEvent) {
+          addMelodicEvent(slot, melodicEvent);
+        }
+      }
+
+      addSlotLyric(slot, tick.lyric ?? tick.events.find((event) => Boolean(event.lyric?.trim()))?.lyric ?? null, 0);
+    }
+
+    return { slots };
+  });
+}
+
+function measuresFromMidiTicks(
+  ticks: MidiTickEvent[],
+  instrument: Exclude<InstrumentType, "DRUM">,
+  useDerivedPitchMap: boolean,
+): MelodicMeasure[] {
+  const grouped = new Map<number, MidiTickEvent[]>();
+  for (const tick of ticks) {
+    const measureIndex = Math.max(0, tick.measure - 1);
+    const entries = grouped.get(measureIndex) ?? [];
+    entries.push(tick);
+    grouped.set(measureIndex, entries);
+  }
+
+  const measureCount = Math.max(1, Math.max(...grouped.keys(), 0) + 1);
+  return Array.from({ length: measureCount }, (_, measureIndex) => {
+    const slots = emptyMelodicSlots();
+    for (const tick of grouped.get(measureIndex) ?? []) {
+      const slot = slots[clampSlot(tick.slot)];
+      const melodicEvent = useDerivedPitchMap
+        ? melodicEventFromDrumLike(tick, tick.voice, instrument)
+        : melodicEventFromAnySource(tick, tick.voice, instrument);
+      if (melodicEvent) {
+        addMelodicEvent(slot, melodicEvent);
+      }
+
+      addSlotLyric(slot, tick.lyric ?? null, 0);
+    }
+    return { slots };
+  });
+}
+
+function measuresFromScoreEvents(
+  events: ScoreEvent[],
+  bpm: number,
+  instrument: Exclude<InstrumentType, "DRUM">,
+  useDerivedPitchMap: boolean,
+): MelodicMeasure[] {
+  const beatSeconds = 60 / Math.max(bpm || 120, 1);
+  const measureSeconds = beatSeconds * 4;
+  const grouped = new Map<number, ScoreEvent[]>();
+
+  for (const event of [...events].sort((left, right) => left.time - right.time)) {
+    const measureIndex = Math.max(0, Math.floor(event.time / measureSeconds));
+    const entries = grouped.get(measureIndex) ?? [];
+    entries.push(event);
+    grouped.set(measureIndex, entries);
+  }
+
+  const measureCount = Math.max(1, Math.max(...grouped.keys(), 0) + 1);
+  return Array.from({ length: measureCount }, (_, measureIndex) => {
+    const slots = emptyMelodicSlots();
+    for (const event of grouped.get(measureIndex) ?? []) {
+      const slotIndex = Math.min(
+        SLOTS_PER_MEASURE - 1,
+        Math.max(0, Math.round((event.time - measureIndex * measureSeconds) / (beatSeconds / 4))),
+      );
+      const slot = slots[slotIndex];
+      const melodicEvent = useDerivedPitchMap
+        ? melodicEventFromDrumLike(event, 1, instrument)
+        : melodicEventFromAnySource(event, 1, instrument);
+      if (melodicEvent) {
+        addMelodicEvent(slot, melodicEvent);
+      }
+
+      addSlotLyric(slot, event.lyric ?? null, 0);
+    }
+    return { slots };
+  });
+}
+
+function melodicEventFromAnySource(
+  event: { confidence?: number; lyric?: string | null; midi_note?: number; staff_key?: string | null },
+  voice: VoiceNumber,
+  instrument: Exclude<InstrumentType, "DRUM">,
+): MelodicNoteEvent | null {
+  const normalizedKey = normalizeStaffKey(event.staff_key ?? null);
+  const staffKey = normalizedKey ?? staffKeyFromMidi(event.midi_note ?? null) ?? fallbackStaffKeyForInstrument(instrument, voice);
+  if (!staffKey) {
+    return null;
+  }
+
+  return {
+    confidence: event.confidence ?? 1,
+    lyric: event.lyric ?? null,
+    midiNote: event.midi_note ?? null,
+    staffKey,
+    voice,
+  };
+}
+
+function melodicEventFromDrumLike(
+  event: { confidence?: number; drum?: DrumNote; lyric?: string | null },
+  voice: VoiceNumber,
+  instrument: Exclude<InstrumentType, "DRUM">,
+): MelodicNoteEvent | null {
+  if (!event.drum) {
+    return null;
+  }
+
+  const staffKey =
+    instrument === "KEYBOARD" ? DERIVED_KEYBOARD_PITCHES[voice][event.drum] : DERIVED_SINGLE_STAFF_PITCHES[instrument][event.drum];
+
+  return {
+    confidence: event.confidence ?? 1,
+    lyric: event.lyric ?? null,
+    midiNote: null,
+    staffKey,
+    voice,
+  };
+}
+
+function emptyMelodicSlots(): MelodicSlot[] {
+  return Array.from({ length: SLOTS_PER_MEASURE }, () => ({
+    lyric: null,
+    lyrics: [],
+    voice1: [],
+    voice2: [],
+  }));
+}
+
+function addMelodicEvent(slot: MelodicSlot, event: MelodicNoteEvent) {
+  const target = event.voice === 1 ? slot.voice1 : slot.voice2;
+  const duplicate = target.find((entry) => entry.staffKey === event.staffKey);
+  if (duplicate) {
+    if (event.confidence > duplicate.confidence) {
+      duplicate.confidence = event.confidence;
+      duplicate.lyric = event.lyric ?? duplicate.lyric;
+      duplicate.midiNote = event.midiNote ?? duplicate.midiNote;
+    }
+    return;
+  }
+
+  target.push(event);
+  target.sort((left, right) => diatonicIndex(left.staffKey) - diatonicIndex(right.staffKey));
+}
+
+function hasAnyLyrics(measures: MelodicMeasure[]): boolean {
+  return measures.some((measure) =>
+    measure.slots.some((slot) => Boolean(slot.lyric?.trim()) || slot.lyrics.some((entry) => Boolean(entry.lyric.trim()))),
+  );
+}
+
+function applyWordsFallback(measures: MelodicMeasure[], words: LyricWord[], bpm: number): MelodicMeasure[] {
+  if (!words.length) {
+    return measures.length ? measures : [{ slots: emptyMelodicSlots() }];
+  }
+
+  const beatSeconds = 60 / Math.max(bpm || 120, 1);
+  const measureSeconds = beatSeconds * 4;
+  const slotSeconds = measureSeconds / SLOTS_PER_MEASURE;
+
+  for (const word of words) {
+    const measureIndex = Math.max(0, Math.floor(word.start / measureSeconds));
+    const measure = ensureMeasure(measures, measureIndex);
+    const measureStart = measureIndex * measureSeconds;
+    const slotIndex = Math.min(
+      SLOTS_PER_MEASURE - 1,
+      Math.max(0, Math.floor((word.start - measureStart) / slotSeconds)),
+    );
+    const targetSlot = firstAvailableLyricSlot(measure.slots, slotIndex);
+    if (targetSlot !== null) {
+      addSlotLyric(measure.slots[targetSlot], word.word.trim().normalize("NFC"), 0);
+    }
+  }
+
+  return measures;
+}
+
+function ensureMeasure(measures: MelodicMeasure[], measureIndex: number): MelodicMeasure {
+  while (measures.length <= measureIndex) {
+    measures.push({ slots: emptyMelodicSlots() });
+  }
+  return measures[measureIndex];
+}
+
+function firstAvailableLyricSlot(slots: MelodicSlot[], preferredSlot: number): number | null {
+  for (let slot = preferredSlot; slot < SLOTS_PER_MEASURE; slot += 1) {
+    if (!slots[slot].lyric?.trim() && slots[slot].lyrics.length === 0) {
+      return slot;
+    }
+  }
+  return null;
+}
+
+function addSlotLyric(slot: MelodicSlot, next: string | null | undefined, row: number) {
+  const cleanNext = next?.trim().normalize("NFC");
+  if (!cleanNext) {
+    return;
+  }
+
+  const cleanRow = Math.max(0, row);
+  slot.lyrics.push({ lyric: cleanNext, row: cleanRow });
+  slot.lyrics.sort((left, right) => left.row - right.row);
+  slot.lyric = mergeLyric(slot.lyric, cleanNext);
+}
+
+function mergeLyric(current: string | null | undefined, next: string | null | undefined): string | null {
+  const cleanNext = next?.trim();
+  if (!cleanNext) {
+    return current ?? null;
+  }
+
+  const cleanCurrent = current?.trim();
+  if (!cleanCurrent) {
+    return cleanNext;
+  }
+  if (cleanCurrent.split(/\s+/).includes(cleanNext)) {
+    return cleanCurrent;
+  }
+  return `${cleanCurrent} ${cleanNext}`;
+}
+
+function resolveInstrumentType(value: SourceTagged | null | undefined): InstrumentType | null {
+  return value?.instrumentType ?? value?.instrument_type ?? null;
+}
+
+function countMeasuresFromTicks(ticks: MidiTickEvent[]): number {
+  return Math.max(1, Math.max(...ticks.map((tick) => tick.measure), 1));
+}
+
+function clampSlot(slot: number): number {
+  return Math.min(SLOTS_PER_MEASURE - 1, Math.max(0, slot));
+}
+
+function normalizeStaffKey(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return /^[a-g][#b]?\/-?\d+$/.test(normalized) ? normalized : null;
+}
+
+function staffKeyFromMidi(midi: number | null): string | null {
+  if (midi === null || !Number.isFinite(midi)) {
+    return null;
+  }
+
+  const noteNames = ["c", "c#", "d", "d#", "e", "f", "f#", "g", "g#", "a", "a#", "b"] as const;
+  const pitchClass = ((Math.round(midi) % 12) + 12) % 12;
+  const octave = Math.floor(Math.round(midi) / 12) - 1;
+  return `${noteNames[pitchClass]}/${octave}`;
+}
+
+function fallbackStaffKeyForInstrument(
+  instrument: Exclude<InstrumentType, "DRUM">,
+  voice: VoiceNumber,
+): string {
+  if (instrument === "KEYBOARD") {
+    return voice === 1 ? "c/5" : "c/3";
+  }
+  if (instrument === "BASS") {
+    return "e/2";
+  }
+  return "e/4";
+}
+
+function diatonicIndex(staffKey: string): number {
+  const match = /^([a-g])[#b]?\/(-?\d+)$/.exec(staffKey);
+  if (!match) {
+    return 0;
+  }
+
+  const diatonicOrder: Record<string, number> = {
+    a: 5,
+    b: 6,
+    c: 0,
+    d: 1,
+    e: 2,
+    f: 3,
+    g: 4,
+  };
+
+  return Number(match[2]) * 7 + diatonicOrder[match[1]];
+}

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -7,6 +7,18 @@ export type DrumNote =
   | "crash"
   | "ride";
 
+export type InstrumentType = "DRUM" | "BASS" | "GUITAR" | "KEYBOARD";
+export type InstrumentNotation = "percussion" | "staff" | "grand";
+export type BassRenderMode = "standard" | "tab" | "both";
+export type BassDuration = "w" | "h" | "q" | "8" | "16";
+export type BassTechnique =
+  | "HAMMER_ON"
+  | "PULL_OFF"
+  | "SLIDE"
+  | "DEAD"
+  | "SLAP"
+  | "POP";
+
 export type ScoreEvent = {
   time: number;
   note: DrumNote;
@@ -81,6 +93,64 @@ export type AnalysisResult = {
   ticks_per_quarter: number;
   midi_ticks: MidiTickEvent[];
   engraved_measures: EngravedMeasure[];
+  instrumentType?: InstrumentType;
+  instrument_type?: InstrumentType;
+  bassSpec?: BassSpec;
+  bass_spec?: BassSpec;
+  BASS_SPEC?: BassSpec;
+  tracks?: AnalysisTrack[];
+};
+
+export type AnalysisTrack = {
+  id?: string;
+  label?: string;
+  name?: string;
+  bpm?: number;
+  notation?: InstrumentNotation;
+  instrumentType?: InstrumentType;
+  instrument_type?: InstrumentType;
+  bassSpec?: BassSpec;
+  bass_spec?: BassSpec;
+  BASS_SPEC?: BassSpec;
+  events?: ScoreEvent[];
+  words?: LyricWord[];
+  ticks_per_quarter?: number;
+  midi_ticks?: MidiTickEvent[];
+  engraved_measures?: EngravedMeasure[];
+};
+
+export type BassSpec = {
+  mode?: BassRenderMode;
+  notes: BassSpecNote[];
+};
+
+export type BassSpecNote = {
+  id?: string;
+  time?: number;
+  measure?: number;
+  slot?: number;
+  duration?: BassDuration;
+  duration_slots?: number;
+  midi_note?: number;
+  staff_key?: string | null;
+  string?: 1 | 2 | 3 | 4;
+  fret?: number | "X" | "x" | "0";
+  lyric?: string | null;
+  confidence?: number;
+  chord?: string | null;
+  harmony?: string | null;
+  technique?: string | null;
+  techniques?: string[];
+  is_dead?: boolean;
+  is_staccato?: boolean;
+  tie_to_next?: boolean;
+  tie_from_previous?: boolean;
+  slur_to_next?: boolean;
+  slur_from_previous?: boolean;
+  prefer_string?: 1 | 2 | 3 | 4;
+  slap_style?: boolean;
+  is_pop?: boolean;
+  is_pull_off?: boolean;
 };
 
 export type AnalysisJobStatus = {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -147,6 +147,9 @@ export type BassSpecNote = {
   tie_from_previous?: boolean;
   slur_to_next?: boolean;
   slur_from_previous?: boolean;
+  slide_direction?: "up" | "down" | null;
+  slide_out_direction?: "up" | "down" | null;
+  slide_out_to_nowhere?: boolean;
   prefer_string?: 1 | 2 | 3 | 4;
   slap_style?: boolean;
   is_pop?: boolean;


### PR DESCRIPTION
﻿## 변경 내용 요약
- 드럼, 베이스, 기타, 키보드 뷰를 전환할 수 있는 멀티 악기 악보 UI를 추가했습니다.
- 악기별 렌더링을 감싸는 `ScoreSheet`와 멜로딕 악기용 `MelodicSheet`를 추가해 단일 보표와 그랜드 스태프를 지원했습니다.
- API에 명시적 트랙이 없을 때는 드럼 타이밍 맵 기반의 derived preview를 만들어 다른 악기 뷰를 미리 볼 수 있게 했습니다.

## 변경 이유
- 현재 화면은 드럼 악보만 보여줘서 다른 파트 시점을 전환하며 확인할 수 없었습니다.
- 멜로딕 악기는 퍼커션과 다른 보표 구조가 필요해 별도 렌더링 레이어가 필요했습니다.
- 백엔드가 아직 다중 악기 트랙을 완전히 주지 않더라도 프론트엔드에서 미리보기 경험을 제공할 필요가 있었습니다.

## 주요 변경 사항
- `page.tsx`에 악기 선택기, 선택된 악기 상태, derived preview 상태 표시를 추가하고 `ScoreSheet`를 사용하도록 바꿨습니다.
- `ScoreSheet.tsx`에서 드럼과 멜로딕 악기 렌더러를 분기하고 동일한 출력 인터페이스를 유지했습니다.
- `MelodicSheet.tsx`를 추가해 staff/grand notation, 페이지형 악보, 재생 오버레이, 가사 레인을 렌더링하도록 구현했습니다.
- `scoreTracks.ts`와 `types.ts`에서 다중 악기 트랙 타입, derived pitch map, instrument view 해석 로직을 추가했습니다.
- `globals.css`에 악기 선택 버튼과 트랙 상태 UI 스타일을 추가했습니다.

## 테스트 방법
- `npm --workspace apps/web run lint`
- `npm --workspace apps/web run build`
